### PR TITLE
Fix r-base and openjdk integration

### DIFF
--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -23,6 +23,7 @@ Linux() {
     # We cannot use cairo without this since it depends on a good few X11 things.
     export PKG_CONFIG_PATH=/usr/lib/pkgconfig
     export JAVA_CPPFLAGS="-I$JAVA_HOME/include -I$JAVA_HOME/include/linux"
+    export JAVA_LIBS="-Wl,-rpath,$JAVA_LD_LIBRARY_PATH -L$JAVA_LD_LIBRARY_PATH -ljvm"
     export R_JAVA_LD_LIBRARY_PATH=${JAVA_HOME}/lib
 
     mkdir -p $PREFIX/lib
@@ -58,8 +59,8 @@ Linux() {
 Mingw_w64_autotools() {
     . ${RECIPE_DIR}/java.rc
     if [ -n "$JDK_HOME" -a -n "$JAVA_HOME" ]; then
-        export JAVA_CPPFLAGS="-I$JDK_HOME/include -I$JDK_HOME/include/linux"
-        export JAVA_LD_LIBRARY_PATH=${JAVA_HOME}/lib/amd64/server
+        export JAVA_CPPFLAGS="-I$JAVA_HOME/include -I$JAVA_HOME/include/linux"
+        export JAVA_LIBS="-Wl,-rpath,$JAVA_LD_LIBRARY_PATH -L$JAVA_LD_LIBRARY_PATH -ljvm"
     else
         echo warning: JDK_HOME and JAVA_HOME not set
     fi
@@ -315,6 +316,8 @@ CXX=clang++
 F77=gfortran
 OBJC=clang
 EOF
+    export JAVA_CPPFLAGS="-I$JAVA_HOME/include -I$JAVA_HOME/include/darwin"
+    export JAVA_LIBS="-Wl,-rpath,$JAVA_LD_LIBRARY_PATH -L$JAVA_LD_LIBRARY_PATH -ljvm"
 
     # --without-internal-tzcode to avoid warnings:
     # unknown timezone 'Europe/London'

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -22,7 +22,7 @@ source:
     - 0012-macOS-include-cairo_h-not-cairo-xlib_h.patch
 
 build:
-  number: 4
+  number: 5
   rpaths:
     - lib/R/lib/
     - lib/
@@ -107,11 +107,14 @@ requirements:
     - {{native}}libxml2 2.9.*
 
 test:
+  requires:
+    - openjdk
   commands:
     - R -h
     - R --version
     - Rscript --version
     - Rscript -e  'cat("ok\\n")'
+    - R CMD javareconf  # [unix]
     - open  # [win]
     # There doesn't seem to be a way to test this one
     # - RSetReg        # [win]
@@ -133,3 +136,4 @@ extra:
   recipe-maintainers:
     - johanneskoester
     - ocefpaf
+    - sodre


### PR DESCRIPTION
The issue is not with rJava, instead it is r-base that is misconfigured.
We can not trust the CI tests completely, it is giving false positives...

The change to the code base is to integrate the hacks is in conda-forge/staged-recipes#2870 during r-base's build time. This is currently done for

- [x] Linux
- [x] OSX

This fix will be skipped for:
- [X] Windows

The outcome is that anything that depended in java for R studio would need to be rebuilt.