### PR TITLE
add standalone math libraries

### DIFF
--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -49,6 +49,10 @@ Linux() {
     # make check-all -j1 V=1 > $(uname)-make-check.log 2>&1 || make check-all -j1 V=1 > $(uname)-make-check.2.log 2>&1
 
     make install
+
+    # install standalone libraries in include and lib
+    cd src/nmath/standalone
+    make install
 }
 
 # This was an attempt to see how far we could get with using Autotools as things
@@ -337,6 +341,10 @@ EOF
     make -j${CPU_COUNT}
     # echo "Running make check-all, this will take some time ..."
     # make check-all -j1 V=1 > $(uname)-make-check.log 2>&1
+    make install
+
+    # install standalone libraries in include and lib
+    cd src/nmath/standalone
     make install
 }
 


### PR DESCRIPTION
Hi all,

I'm attempting to add the [R standalone libraries](https://cran.r-project.org/doc/manuals/r-release/R-admin.html#The-standalone-Rmath-library). These libraries allow non-R code to link against the R base math routines.

There are two key files:

- `include/Rmath.h`
- `lib/libRmath.*`

I'm not entirely convinced that the library is getting pulled in -- perhaps there is something I am missing in the recipe? Any chance someone could help identify the issue?

Also, would be great if someone with a windows machine could figure out how to get it to work there...

I'd like to include these for general use, but I'm also interested in writing a rule for [FastQTL](http://fastqtl.sourceforge.net/) in bioconda.


Thanks,

Harold