### PR TITLE
Upgrade `ncurses` requirement

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -82,7 +82,7 @@ requirements:
 
   run:
     - readline 6.2*            # [not win]
-    - ncurses 5.9*             # [not win]
+    - ncurses >=5.9            # [not win]
     - libgcc                   # [not win]
     - {{native}}gcc-libs       # [win]
     - jpeg 9*                  # [not win]


### PR DESCRIPTION
When trying to install `r-base` in the `continuumio/anaconda3/` docker container, conda installs version 3.3.2 instead of the latest. No complains are observed when installed on a system level version of anaconda.

Trying to force the version shows the issue is an incompatibility between `r-base` and `libedit` on the `ncurses` version, with `r-base` requiring 5.9 and `libedit` asking for 6.0

Could we relax/upgrade r-base requirement for the `ncurses` version?