### PR TITLE
Update R 3.3.2 pins to match 3.4.1.

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -36,6 +36,7 @@ install:
     # Add path, activate `conda` and update conda.
     - cmd: call %CONDA_INSTALL_LOCN%\Scripts\activate.bat
     - cmd: conda update --yes --quiet conda
+    - cmd: conda config --system --add pinned_packages defaults::conda
 
     - cmd: set PYTHONUNBUFFERED=1
 

--- a/recipe/0014-Linux-macOS-zlib-version-check.patch
+++ b/recipe/0014-Linux-macOS-zlib-version-check.patch
@@ -1,0 +1,20 @@
+diff --git a/m4/R.m4 b/m4/R.m4
+index 1440898..81e8b3f 100644
+--- a/m4/R.m4
++++ b/m4/R.m4
+@@ -3105,10 +3105,11 @@ AC_DEFUN([_R_HEADER_ZLIB],
+ #include <string.h>
+ #include <zlib.h>
+ int main() {
+-#ifdef ZLIB_VERSION
+-/* Work around Debian bug: it uses 1.2.3.4 even though there was no such
+-   version on the master site zlib.net */
+-  exit(strncmp(ZLIB_VERSION, "1.2.5", 5) < 0);
++#ifdef ZLIB_VERNUM
++  if (ZLIB_VERNUM < 0x1250) {
++    exit(1);
++  }
++  exit(0);
+ #else
+   exit(1);
+ #endif

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -55,7 +55,7 @@ requirements:
     - texlive-core             # [osx]
     - {{posix}}pkg-config
     - {{posix}}autoconf
-    - {{posix}}automake-wrapper # [win]
+    - {{posix}}automake-wrapper  # [win]
     - {{posix}}automake        # [not win]
     - {{native}}bzip2 1.0.*    # [not osx]
     - {{native}}libjpeg-turbo  # [win]
@@ -111,7 +111,7 @@ requirements:
     - zlib 1.2.11              # [not win]
     - {{native}}zlib           # [win]
     - {{native}}gsl
-    - libtiff >=4.0.8,<4.0.10 # [not win]
+    - libtiff >=4.0.8,<4.0.10  # [not win]
     - {{native}}libtiff        # [win]
     - {{native}}libxml2 2.9.*
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -21,6 +21,7 @@ source:
     - 0009-R-3.3.0-Use-AC_SEARCH_LIBS-to-search-for-ncurses.patch
     - 0011-Linux-Do-not-modify-LD_LIBRARY_PATH.patch
     - 0012-macOS-include-cairo_h-not-cairo-xlib_h.patch
+    - 0014-Linux-macOS-zlib-version-check.patch  # [not win]
 
 build:
   number: 7

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -23,7 +23,7 @@ source:
     - 0012-macOS-include-cairo_h-not-cairo-xlib_h.patch
 
 build:
-  number: 6
+  number: 7
   rpaths:
     - lib/R/lib/
     - lib/
@@ -45,26 +45,26 @@ requirements:
     - m2-texinfo               # [win]
     - m2-curl                  # [win]
     - m2-p7zip                 # [win]
-    - readline 6.2*            # [not win]
-    - ncurses 5.9*             # [not win]
+    - readline 7.0             # [not win]
+    - ncurses 5.9              # [not win]
     - gcc                      # [not win]
     - jpeg 9*                  # [not win]
-    - curl                     # [not win]
+    - curl >=7.44.0,<8         # [not win]
     - xz 5.2.*                 # [not win]
-    - libpng >=1.6.22,<1.6.31     # [not win]
+    - libpng >=1.6.32,<1.6.35  # [not win]
     - texlive-core             # [osx]
     - {{posix}}pkg-config
     - {{posix}}autoconf
-    - {{posix}}automake-wrapper  # [win]
-    - {{posix}}automake          # [not win]
+    - {{posix}}automake-wrapper # [win]
+    - {{posix}}automake        # [not win]
     - {{native}}bzip2 1.0.*    # [not osx]
     - {{native}}libjpeg-turbo  # [win]
     - {{native}}toolchain      # [win]
     - {{native}}libiconv       # [win]
-    - {{native}}gmp            # [win]
+    - {{native}}gmp 6.1.*      # [win]
     - {{native}}fftw           # [win]
     - {{native}}xz             # [win]
-    - {{native}}mpfr           # [win]
+    - {{native}}mpfr 3.1.*     # [win]
     - {{native}}libsndfile     # [win]
     - {{native}}bwidget        # [win]
     - {{native}}tktable        # [win]
@@ -74,29 +74,30 @@ requirements:
     - {{native}}pcre 8.39*     # [not win]
     - {{native}}pcre           # [win]
     - {{native}}tk             # [win]
-    - {{native}}tk 8.5.*       # [not win]
-    - zlib 1.2.8  # [not win]
-    - {{native}}zlib  # [win]
+    - {{native}}tk 8.6.*       # [not win]
+    - zlib 1.2.11              # [not win]
+    - {{native}}zlib           # [win]
     - {{native}}gsl
-    - {{native}}libtiff >=4.0.3,<4.0.8
+    - libtiff >=4.0.8,<4.0.10  # [not win]
+    - {{native}}libtiff        # [win]
     - {{native}}libxml2 2.9.*
 
   run:
-    - readline 6.2*            # [not win]
-    - ncurses 5.9*             # [not win]
+    - readline 7.0             # [not win]
+    - ncurses 5.9              # [not win]
     - libgcc                   # [not win]
     - {{native}}gcc-libs       # [win]
     - jpeg 9*                  # [not win]
-    - curl                     # [not win]
+    - curl >=7.44.0,<8         # [not win]
     - xz 5.2.*                 # [not win]
-    - libpng >=1.6.22,<1.6.31     # [not win]
+    - libpng >=1.6.32,<1.6.35  # [not win]
     - {{native}}bzip2 1.0.*    # [not osx]
     - {{native}}libjpeg-turbo  # [win]
     - {{native}}libiconv       # [win]
-    - {{native}}gmp            # [win]
+    - {{native}}gmp 6.1.*      # [win]
     - {{native}}fftw           # [win]
     - {{native}}xz             # [win]
-    - {{native}}mpfr           # [win]
+    - {{native}}mpfr 3.1.*     # [win]
     - {{native}}libsndfile     # [win]
     - {{native}}bwidget        # [win]
     - {{native}}tktable        # [win]
@@ -106,11 +107,12 @@ requirements:
     - {{native}}pcre 8.39*     # [not win]
     - {{native}}pcre           # [win]
     - {{native}}tk             # [win]
-    - {{native}}tk 8.5.*       # [not win]
-    - zlib 1.2.11  # [not win]
-    - {{native}}zlib  # [win]
+    - {{native}}tk 8.6.*       # [not win]
+    - zlib 1.2.11              # [not win]
+    - {{native}}zlib           # [win]
     - {{native}}gsl
-    - {{native}}libtiff >=4.0.3,<4.0.8
+    - libtiff >=4.0.8,<4.0.10 # [not win]
+    - {{native}}libtiff        # [win]
     - {{native}}libxml2 2.9.*
 
 test:


### PR DESCRIPTION
I manually updated the pins to match the current [meta.yaml for 3.4.1](https://github.com/conda-forge/r-base-feedstock/blob/ed368f40fa1d86764af2caca1ddee2e4cf238892/recipe/meta.yaml). I couldn't use [pin_the_slow_way.py](https://github.com/conda-forge/conda-forge.github.io/blob/358baaf345667678b2514c9e2ad427429a38bc48/scripts/pin_the_slow_way.py) because it requires conda-forge-admin permissions.

ping @ocefpaf @bgruening 