### PR TITLE
conda activate sets RSTUDIO_WHICH_R

### DIFF
--- a/recipe/activate-r-base.sh
+++ b/recipe/activate-r-base.sh
@@ -1,2 +1,3 @@
 #!/usr/bin/env sh
 R CMD javareconf > /dev/null 2>&1 || true
+export RSTUDIO_WHICH_R="$CONDA_PREFIX/bin/R"

--- a/recipe/activate-r-base.sh
+++ b/recipe/activate-r-base.sh
@@ -1,3 +1,8 @@
 #!/usr/bin/env sh
 R CMD javareconf > /dev/null 2>&1 || true
+
+# store existing RSTUDIO_WHICH_R
+if [[ ! -z ${RSTUDIO_WHICH_R+x} ]]; then
+  export RSTUDIO_WHICH_R_PREV="$RSTUDIO_WHICH_R"
+fi
 export RSTUDIO_WHICH_R="$CONDA_PREFIX/bin/R"

--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -348,11 +348,15 @@ case `uname` in
         Darwin
         mkdir -p ${PREFIX}/etc/conda/activate.d
         cp "${RECIPE_DIR}"/activate-${PKG_NAME}.sh ${PREFIX}/etc/conda/activate.d/activate-${PKG_NAME}.sh
+        mkdir -p ${PREFIX}/etc/conda/deactivate.d
+        cp "${RECIPE_DIR}"/deactivate-${PKG_NAME}.sh ${PREFIX}/etc/conda/deactivate.d/deactivate-${PKG_NAME}.sh
         ;;
     Linux)
         Linux
         mkdir -p ${PREFIX}/etc/conda/activate.d
         cp "${RECIPE_DIR}"/activate-${PKG_NAME}.sh ${PREFIX}/etc/conda/activate.d/activate-${PKG_NAME}.sh
+        mkdir -p ${PREFIX}/etc/conda/deactivate.d
+        cp "${RECIPE_DIR}"/deactivate-${PKG_NAME}.sh ${PREFIX}/etc/conda/deactivate.d/deactivate-${PKG_NAME}.sh
         ;;
     MINGW*)
         # Mingw_w64_autotools

--- a/recipe/deactivate-r-base.sh
+++ b/recipe/deactivate-r-base.sh
@@ -1,0 +1,2 @@
+#!/usr/bin/env sh
+unset RSTUDIO_WHICH_R

--- a/recipe/deactivate-r-base.sh
+++ b/recipe/deactivate-r-base.sh
@@ -1,2 +1,9 @@
 #!/usr/bin/env sh
-unset RSTUDIO_WHICH_R
+
+# restore pre-existing RSTUDIO_WHICH_R
+if [[ ! -z ${RSTUDIO_WHICH_R_PREV+x} ]]; then
+  export RSTUDIO_WHICH_R="$RSTUDIO_WHICH_R_PREV"
+  unset RSTUDIO_WHICH_R_PREV
+else
+  unset RSTUDIO_WHICH_R
+fi

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -23,7 +23,7 @@ source:
     - 0013-javareconf-do-not-fail-on-compile-fail.patch
 
 build:
-  number: 0
+  number: 1
   merge_build_host: True   # [win]
   rpaths:
     - lib/R/lib/


### PR DESCRIPTION
<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a fork of the feedstock to propose changes
* [x] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/conda_smithy.html#how-to-re-render ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
This PR enables RStudio to find the R executable from the active conda environment, when opening RStudio from the command-line.