### PR TITLE
Isolate conda R from system user library.

### DIFF
--- a/recipe/0019-Disable-default-user-libraries.patch
+++ b/recipe/0019-Disable-default-user-libraries.patch
@@ -1,0 +1,27 @@
+From 8c85f70505694dd181ef47a47896007b150f94c3 Mon Sep 17 00:00:00 2001
+From: John Blischak <jdblischak@gmail.com>
+Date: Thu, 13 Dec 2018 14:12:32 -0500
+Subject: [PATCH] Disable default user libraries.
+
+---
+ etc/Renviron.in | 4 ++--
+ 1 file changed, 2 insertions(+), 2 deletions(-)
+
+diff --git a/etc/Renviron.in b/etc/Renviron.in
+index 49604e54c2..38efb63bb9 100644
+--- a/etc/Renviron.in
++++ b/etc/Renviron.in
+@@ -39,8 +39,8 @@ TAR=${TAR-'@TAR@'}
+ ## System and compiler types.
+ R_SYSTEM_ABI='@R_SYSTEM_ABI@'
+ 
+-@BUILD_AQUA_FALSE@R_LIBS_USER=${R_LIBS_USER-'~/R/@R_PLATFORM@-library/@MAJ_MIN_VERSION@'}
+-@BUILD_AQUA_TRUE@R_LIBS_USER=${R_LIBS_USER-'~/Library/R/@MAJ_MIN_VERSION@/library'}
++#@BUILD_AQUA_FALSE@R_LIBS_USER=${R_LIBS_USER-'~/R/@R_PLATFORM@-library/@MAJ_MIN_VERSION@'}
++#@BUILD_AQUA_TRUE@R_LIBS_USER=${R_LIBS_USER-'~/Library/R/@MAJ_MIN_VERSION@/library'}
+ 
+ ### Local Variables: ***
+ ### mode: sh ***
+-- 
+2.17.1
+

--- a/recipe/activate-r-base.sh
+++ b/recipe/activate-r-base.sh
@@ -6,3 +6,9 @@ if [[ ! -z ${RSTUDIO_WHICH_R+x} ]]; then
   export RSTUDIO_WHICH_R_PREV="$RSTUDIO_WHICH_R"
 fi
 export RSTUDIO_WHICH_R="$CONDA_PREFIX/bin/R"
+
+# store existing R_LIBS_USER
+if [[ ! -z ${R_LIBS_USER+x} ]]; then
+  export R_LIBS_USER_PREV="$R_LIBS_USER"
+fi
+unset R_LIBS_USER

--- a/recipe/activate-r-base.sh
+++ b/recipe/activate-r-base.sh
@@ -7,8 +7,8 @@ if [[ ! -z ${RSTUDIO_WHICH_R+x} ]]; then
 fi
 export RSTUDIO_WHICH_R="$CONDA_PREFIX/bin/R"
 
-# store existing R_LIBS_USER
-if [[ ! -z ${R_LIBS_USER+x} ]]; then
+# store existing R_LIBS_USER if the user has not set CONDA_KEEP_R_LIBS_USER
+if [[ ! -z ${R_LIBS_USER+x} && -z ${CONDA_KEEP_R_LIBS_USER+x} ]]; then
   export R_LIBS_USER_PREV="$R_LIBS_USER"
 fi
 unset R_LIBS_USER

--- a/recipe/activate-r-base.sh
+++ b/recipe/activate-r-base.sh
@@ -12,3 +12,9 @@ if [[ ! -z ${R_LIBS_USER+x} && -z ${CONDA_KEEP_R_LIBS_USER+x} ]]; then
   export R_LIBS_USER_PREV="$R_LIBS_USER"
 fi
 unset R_LIBS_USER
+
+# store existing R_LIBS if the user has not set CONDA_KEEP_R_LIBS
+if [[ ! -z ${R_LIBS+x} && -z ${CONDA_KEEP_R_LIBS+x} ]]; then
+  export R_LIBS_PREV="$R_LIBS"
+fi
+unset R_LIBS

--- a/recipe/deactivate-r-base.sh
+++ b/recipe/deactivate-r-base.sh
@@ -7,3 +7,9 @@ if [[ ! -z ${RSTUDIO_WHICH_R_PREV+x} ]]; then
 else
   unset RSTUDIO_WHICH_R
 fi
+
+# restore pre-existing R_LIBS_USER
+if [[ ! -z ${R_LIBS_USER_PREV+x} ]]; then
+  export R_LIBS_USER="$R_LIBS_USER_PREV"
+  unset R_LIBS_USER_PREV
+fi

--- a/recipe/deactivate-r-base.sh
+++ b/recipe/deactivate-r-base.sh
@@ -13,3 +13,9 @@ if [[ ! -z ${R_LIBS_USER_PREV+x} ]]; then
   export R_LIBS_USER="$R_LIBS_USER_PREV"
   unset R_LIBS_USER_PREV
 fi
+
+# restore pre-existing R_LIBS
+if [[ ! -z ${R_LIBS_PREV+x} ]]; then
+  export R_LIBS="$R_LIBS_PREV"
+  unset R_LIBS_PREV
+fi

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -31,7 +31,7 @@ source:
 
 build:
   merge_build_host: True  # [win]
-  number: 3
+  number: 4
   rpaths:
     - lib/R/lib/
     - lib/

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -178,6 +178,9 @@ test:
     - Rscript -e "stopifnot(capabilities('jpeg'), TRUE)"
     - Rscript -e "stopifnot(capabilities('png'), TRUE)"
     - if not exist %PREFIX%\\Lib\\R\\bin\\x64\\R.lib exit 1  # [win]
+    - Rscript test-isolation-setup.R
+    - Rscript test-isolation.R
+    - Rscript test-isolation-teardown.R
   files:
     - test-svg.R
     - test-isolation-setup.R

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -27,6 +27,7 @@ source:
     - 0015-link-Xt-to-uuid.patch
     - 0017-Check-for-changes-then-forcibly-mv-in-javareconf.in.patch
     - 0018-Use-LAPACK_LDFLAGS-in-Rlapack_la_LIBADD.patch
+    - 0019-Disable-default-user-libraries.patch
 
 build:
   merge_build_host: True  # [win]
@@ -179,6 +180,9 @@ test:
     - if not exist %PREFIX%\\Lib\\R\\bin\\x64\\R.lib exit 1  # [win]
   files:
     - test-svg.R
+    - test-isolation-setup.R
+    - test-isolation.R
+    - test-isolation-teardown.R
 
 about:
   home: http://www.r-project.org/

--- a/recipe/test-isolation-setup.R
+++ b/recipe/test-isolation-setup.R
@@ -1,0 +1,16 @@
+print(.libPaths())
+os <- .Platform$OS.type
+major <- R.version$major
+minor <- substr(1, 1, R.version$minor)
+platform <- R.version$platform
+
+if (os == "unix" || os == "windows") {
+  d <- sprintf("~/R/%s-library/%s.%s", platform, major, minor)
+} else if (os == "darwin") {
+  d <- sprintf("~/Library/R/%s.%s/library/", major, minor)
+}
+
+d_exists <- dir.exists(d)
+if (!d_exists) {
+  dir.create(d, recursive = TRUE)
+}

--- a/recipe/test-isolation-teardown.R
+++ b/recipe/test-isolation-teardown.R
@@ -1,0 +1,24 @@
+print(.libPaths())
+os <- .Platform$OS.type
+major <- R.version$major
+minor <- substr(1, 1, R.version$minor)
+platform <- R.version$platform
+
+if (os == "unix" || os == "windows") {
+  d <- sprintf("~/R/%s-library/%s.%s", platform, major, minor)
+} else if (os == "darwin") {
+  d <- sprintf("~/Library/R/%s.%s/library/", major, minor)
+}
+
+# There were 3 nested subdirectories added for every OS. Only remove if empty
+if (length(dir(d)) == 0) {
+  unlink(d)
+}
+d <- dirname(d)
+if (length(dir(d)) == 0) {
+  unlink(d)
+}
+d <- dirname(d)
+if (length(dir(d)) == 0) {
+  unlink(d)
+}

--- a/recipe/test-isolation.R
+++ b/recipe/test-isolation.R
@@ -1,0 +1,2 @@
+# There should only be one library directory for a local conda R installation
+stopifnot(length(.libPaths()) == 1)


### PR DESCRIPTION
<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a fork of the feedstock to propose changes
* [x] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [ ] [Re-rendered]( https://conda-forge.org/docs/conda_smithy.html#how-to-re-render ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [ ] Ensured the license file is being packaged.

It's a constant frustration for me that conda R uses the R packages installed in the R user library. This is also a major limitation when trying to convince new conda users about the reproducibility benefits of conda.

This PR attempts to do the following:
* Disable the default setting of R_LIBS_USER by r-base
* Temporarily unsets any custom R_LIBS_USER set by the user
* Tests the isolation during package creation by creating an empty user library that matches the pattern that would be used on that OS

Note to future self: I created the patch by 1) cloning [r-source](https://github.com/wch/r-source), 2) editing and committing [etc/Renviron.in](https://github.com/wch/r-source/blob/master/etc/Renviron.in), and 3) running `git format-patch HEAD~1`.

This issue has previously been discussed in #37.

cc: @mingwandroid @ebolyen @bgruening @isuruf 