### PR TITLE
Split the recipe into r-base-core and r-base.

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -3,7 +3,7 @@
 {% set version = '3.6.1' %}
 
 package:
-  name: r-base
+  name: r-base-core
   version: {{ version }}
 
 source:
@@ -30,7 +30,7 @@ source:
 
 build:
   merge_build_host: True  # [win]
-  number: 3
+  number: 4
   rpaths:
     - lib/R/lib/
     - lib/
@@ -178,6 +178,15 @@ test:
     - Rscript -e "stopifnot(capabilities('png'), TRUE)"
   files:
     - test-svg.R
+
+outputs:
+  - name: r-base-core
+
+  - name: r-base
+    requirements:
+      run:
+        - {{ pin_subpackage('r-base-core', exact=True) }}
+        - mscorefonts
 
 about:
   home: http://www.r-project.org/


### PR DESCRIPTION
This PR uses the [outputs metadata section](https://docs.conda.io/projects/conda-build/en/latest/resources/define-metadata.html#outputs-section) to split the r-base recipe. The idea is that r-base will include optional packages that are useful, but not strictly required to run R. For context see https://github.com/conda-forge/r-base-feedstock/issues/91#issuecomment-512345408

cc @ocefpaf @bgruening 

What other optional packages should be included in r-base but not r-base-core?

<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a fork of the feedstock to propose changes
* [x] Bumped the build number (if the version is unchanged)
* [ ] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
