### PR TITLE
Lock activate-r-base.sh during javareconf

### DIFF
--- a/recipe/activate-r-base.sh
+++ b/recipe/activate-r-base.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env sh
-R CMD javareconf > /dev/null 2>&1 || true
+flock --timeout 60 "$0" R CMD javareconf > /dev/null 2>&1 || true
 
 # store existing RSTUDIO_WHICH_R
 if [[ ! -z ${RSTUDIO_WHICH_R+x} ]]; then


### PR DESCRIPTION
Fix  conda-forge/r-base-feedstock#67 Should work also over NFS unless the system is over 15 years old.

<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x ] Used a [fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [ ] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [ ] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [ ] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
