### PR TITLE
ENH backport gcc and glib migrations to 3.6

### DIFF
--- a/.azure-pipelines/azure-pipelines-linux.yml
+++ b/.azure-pipelines/azure-pipelines-linux.yml
@@ -8,11 +8,14 @@ jobs:
     vmImage: ubuntu-16.04
   strategy:
     matrix:
-      linux_target_platformlinux-64:
-        CONFIG: linux_target_platformlinux-64
+      linux_64_c_compiler_version7cxx_compiler_version7fortran_compiler_version7target_platformlinux-64:
+        CONFIG: linux_64_c_compiler_version7cxx_compiler_version7fortran_compiler_version7target_platformlinux-64
         UPLOAD_PACKAGES: 'True'
         DOCKER_IMAGE: condaforge/linux-anvil-comp7
-    maxParallel: 8
+      linux_64_c_compiler_version9cxx_compiler_version9fortran_compiler_version9target_platformlinux-64:
+        CONFIG: linux_64_c_compiler_version9cxx_compiler_version9fortran_compiler_version9target_platformlinux-64
+        UPLOAD_PACKAGES: 'True'
+        DOCKER_IMAGE: condaforge/linux-anvil-comp7
   timeoutInMinutes: 360
 
   steps:
@@ -37,3 +40,5 @@ jobs:
     displayName: Run docker build
     env:
       BINSTAR_TOKEN: $(BINSTAR_TOKEN)
+      FEEDSTOCK_TOKEN: $(FEEDSTOCK_TOKEN)
+      STAGING_BINSTAR_TOKEN: $(STAGING_BINSTAR_TOKEN)

--- a/.azure-pipelines/azure-pipelines-osx.yml
+++ b/.azure-pipelines/azure-pipelines-osx.yml
@@ -5,13 +5,15 @@
 jobs:
 - job: osx
   pool:
-    vmImage: macOS-10.14
+    vmImage: macOS-10.15
   strategy:
     matrix:
-      osx_target_platformosx-64:
-        CONFIG: osx_target_platformosx-64
+      osx_64_fortran_compiler_version7target_platformosx-64:
+        CONFIG: osx_64_fortran_compiler_version7target_platformosx-64
         UPLOAD_PACKAGES: 'True'
-    maxParallel: 8
+      osx_64_fortran_compiler_version9target_platformosx-64:
+        CONFIG: osx_64_fortran_compiler_version9target_platformosx-64
+        UPLOAD_PACKAGES: 'True'
   timeoutInMinutes: 360
 
   steps:
@@ -25,3 +27,5 @@ jobs:
     displayName: Run OSX build
     env:
       BINSTAR_TOKEN: $(BINSTAR_TOKEN)
+      FEEDSTOCK_TOKEN: $(FEEDSTOCK_TOKEN)
+      STAGING_BINSTAR_TOKEN: $(STAGING_BINSTAR_TOKEN)

--- a/.azure-pipelines/azure-pipelines-win.yml
+++ b/.azure-pipelines/azure-pipelines-win.yml
@@ -8,10 +8,9 @@ jobs:
     vmImage: vs2017-win2016
   strategy:
     matrix:
-      win_target_platformwin-64:
-        CONFIG: win_target_platformwin-64
+      win_64_target_platformwin-64:
+        CONFIG: win_64_target_platformwin-64
         UPLOAD_PACKAGES: 'True'
-    maxParallel: 4
   timeoutInMinutes: 360
   variables:
     CONDA_BLD_PATH: D:\\bld\\
@@ -53,7 +52,7 @@ jobs:
 
     - task: CondaEnvironment@1
       inputs:
-        packageSpecs: 'python=3.6 conda-build conda conda-forge::conda-forge-ci-setup=3 pip' # Optional
+        packageSpecs: 'python=3.6 conda-build conda "conda-forge-ci-setup=3" pip' # Optional
         installOptions: "-c conda-forge"
         updateConda: true
       displayName: Install conda-build and activate environment
@@ -92,13 +91,20 @@ jobs:
       env:
         PYTHONUNBUFFERED: 1
       condition: not(contains(variables['CONFIG'], 'vs2008'))
+    - script: |
+        set "FEEDSTOCK_NAME=%BUILD_REPOSITORY_NAME:*/=%"
+        call activate base
+        validate_recipe_outputs "%FEEDSTOCK_NAME%"
+      displayName: Validate Recipe Outputs
 
     - script: |
         set "GIT_BRANCH=%BUILD_SOURCEBRANCHNAME%"
         set "FEEDSTOCK_NAME=%BUILD_REPOSITORY_NAME:*/=%"
         call activate base
-        upload_package  .\ ".\recipe" .ci_support\%CONFIG%.yaml
+        upload_package --validate --feedstock-name="%FEEDSTOCK_NAME%" .\ ".\recipe" .ci_support\%CONFIG%.yaml
       displayName: Upload package
       env:
         BINSTAR_TOKEN: $(BINSTAR_TOKEN)
+        FEEDSTOCK_TOKEN: $(FEEDSTOCK_TOKEN)
+        STAGING_BINSTAR_TOKEN: $(STAGING_BINSTAR_TOKEN)
       condition: and(succeeded(), not(eq(variables['UPLOAD_PACKAGES'], 'False')))

--- a/.ci_support/linux_64_c_compiler_version7cxx_compiler_version7fortran_compiler_version7target_platformlinux-64.yaml
+++ b/.ci_support/linux_64_c_compiler_version7cxx_compiler_version7fortran_compiler_version7target_platformlinux-64.yaml
@@ -1,0 +1,101 @@
+bzip2:
+- '1'
+c_compiler:
+- gcc
+c_compiler_version:
+- '7'
+cairo:
+- '1.16'
+channel_sources:
+- conda-forge,defaults
+channel_targets:
+- conda-forge main
+cxx_compiler:
+- gxx
+cxx_compiler_version:
+- '7'
+docker_image:
+- condaforge/linux-anvil-comp7
+fortran_compiler:
+- gfortran
+fortran_compiler_version:
+- '7'
+freetype:
+- 2.9.1
+glib:
+- 2.64.6
+gsl:
+- '2.6'
+icu:
+- '67'
+jpeg:
+- '9'
+krb5:
+- 1.17.1
+libblas:
+- 3.8 *netlib
+libcurl:
+- '7'
+liblapack:
+- 3.8 *netlib
+libpng:
+- '1.6'
+libssh2:
+- '1'
+libtiff:
+- 4.1.0
+libuuid:
+- 2.32.1
+libxml2:
+- '2.9'
+ncurses:
+- '6.2'
+pango:
+- '1.42'
+pin_run_as_build:
+  bzip2:
+    max_pin: x
+  cairo:
+    max_pin: x.x
+  freetype:
+    max_pin: x
+  jpeg:
+    max_pin: x
+  krb5:
+    max_pin: x.x
+  libcurl:
+    max_pin: x
+  libpng:
+    max_pin: x.x
+  libtiff:
+    max_pin: x
+  libuuid:
+    max_pin: x
+  libxml2:
+    max_pin: x.x
+  ncurses:
+    max_pin: x.x
+  pango:
+    max_pin: x.x
+  readline:
+    max_pin: x
+  tk:
+    max_pin: x.x
+  xz:
+    max_pin: x.x
+  zlib:
+    max_pin: x.x
+readline:
+- '8.0'
+target_platform:
+- linux-64
+tk:
+- '8.6'
+xz:
+- '5.2'
+zip_keys:
+- - c_compiler_version
+  - cxx_compiler_version
+  - fortran_compiler_version
+zlib:
+- '1.2'

--- a/.ci_support/linux_64_c_compiler_version9cxx_compiler_version9fortran_compiler_version9target_platformlinux-64.yaml
+++ b/.ci_support/linux_64_c_compiler_version9cxx_compiler_version9fortran_compiler_version9target_platformlinux-64.yaml
@@ -3,7 +3,7 @@ bzip2:
 c_compiler:
 - gcc
 c_compiler_version:
-- '7'
+- '9'
 cairo:
 - '1.16'
 channel_sources:
@@ -13,17 +13,17 @@ channel_targets:
 cxx_compiler:
 - gxx
 cxx_compiler_version:
-- '7'
+- '9'
 docker_image:
 - condaforge/linux-anvil-comp7
 fortran_compiler:
 - gfortran
 fortran_compiler_version:
-- '7'
+- '9'
 freetype:
 - 2.9.1
 glib:
-- '2.58'
+- 2.64.6
 gsl:
 - '2.6'
 icu:
@@ -37,7 +37,7 @@ libblas:
 libcurl:
 - '7'
 liblapack:
-- 3.8.0 *netlib
+- 3.8 *netlib
 libpng:
 - '1.6'
 libssh2:
@@ -58,8 +58,6 @@ pin_run_as_build:
   cairo:
     max_pin: x.x
   freetype:
-    max_pin: x
-  icu:
     max_pin: x
   jpeg:
     max_pin: x
@@ -95,5 +93,9 @@ tk:
 - '8.6'
 xz:
 - '5.2'
+zip_keys:
+- - c_compiler_version
+  - cxx_compiler_version
+  - fortran_compiler_version
 zlib:
 - '1.2'

--- a/.ci_support/linux_aarch64_c_compiler_version7cxx_compiler_version7fortran_compiler_version7target_platformlinux-aarch64.yaml
+++ b/.ci_support/linux_aarch64_c_compiler_version7cxx_compiler_version7fortran_compiler_version7target_platformlinux-aarch64.yaml
@@ -29,7 +29,7 @@ fortran_compiler_version:
 freetype:
 - 2.9.1
 glib:
-- '2.58'
+- 2.64.6
 gsl:
 - '2.6'
 icu:
@@ -43,7 +43,7 @@ libblas:
 libcurl:
 - '7'
 liblapack:
-- 3.8.0 *netlib
+- 3.8 *netlib
 libpng:
 - '1.6'
 libssh2:
@@ -64,8 +64,6 @@ pin_run_as_build:
   cairo:
     max_pin: x.x
   freetype:
-    max_pin: x
-  icu:
     max_pin: x
   jpeg:
     max_pin: x
@@ -101,5 +99,9 @@ tk:
 - '8.6'
 xz:
 - '5.2'
+zip_keys:
+- - c_compiler_version
+  - cxx_compiler_version
+  - fortran_compiler_version
 zlib:
 - '1.2'

--- a/.ci_support/linux_aarch64_c_compiler_version9cxx_compiler_version9fortran_compiler_version9target_platformlinux-aarch64.yaml
+++ b/.ci_support/linux_aarch64_c_compiler_version9cxx_compiler_version9fortran_compiler_version9target_platformlinux-aarch64.yaml
@@ -1,0 +1,107 @@
+BUILD:
+- aarch64-conda_cos7-linux-gnu
+bzip2:
+- '1'
+c_compiler:
+- gcc
+c_compiler_version:
+- '9'
+cairo:
+- '1.16'
+cdt_arch:
+- aarch64
+cdt_name:
+- cos7
+channel_sources:
+- conda-forge
+channel_targets:
+- conda-forge main
+cxx_compiler:
+- gxx
+cxx_compiler_version:
+- '9'
+docker_image:
+- condaforge/linux-anvil-aarch64
+fortran_compiler:
+- gfortran
+fortran_compiler_version:
+- '9'
+freetype:
+- 2.9.1
+glib:
+- 2.64.6
+gsl:
+- '2.6'
+icu:
+- '67'
+jpeg:
+- '9'
+krb5:
+- 1.17.1
+libblas:
+- 3.8 *netlib
+libcurl:
+- '7'
+liblapack:
+- 3.8 *netlib
+libpng:
+- '1.6'
+libssh2:
+- '1'
+libtiff:
+- 4.1.0
+libuuid:
+- 2.32.1
+libxml2:
+- '2.9'
+ncurses:
+- '6.2'
+pango:
+- '1.42'
+pin_run_as_build:
+  bzip2:
+    max_pin: x
+  cairo:
+    max_pin: x.x
+  freetype:
+    max_pin: x
+  jpeg:
+    max_pin: x
+  krb5:
+    max_pin: x.x
+  libcurl:
+    max_pin: x
+  libpng:
+    max_pin: x.x
+  libtiff:
+    max_pin: x
+  libuuid:
+    max_pin: x
+  libxml2:
+    max_pin: x.x
+  ncurses:
+    max_pin: x.x
+  pango:
+    max_pin: x.x
+  readline:
+    max_pin: x
+  tk:
+    max_pin: x.x
+  xz:
+    max_pin: x.x
+  zlib:
+    max_pin: x.x
+readline:
+- '8.0'
+target_platform:
+- linux-aarch64
+tk:
+- '8.6'
+xz:
+- '5.2'
+zip_keys:
+- - c_compiler_version
+  - cxx_compiler_version
+  - fortran_compiler_version
+zlib:
+- '1.2'

--- a/.ci_support/linux_ppc64le_c_compiler_version8cxx_compiler_version8fortran_compiler_version8target_platformlinux-ppc64le.yaml
+++ b/.ci_support/linux_ppc64le_c_compiler_version8cxx_compiler_version8fortran_compiler_version8target_platformlinux-ppc64le.yaml
@@ -1,11 +1,9 @@
-MACOSX_DEPLOYMENT_TARGET:
-- '10.9'
 bzip2:
 - '1'
 c_compiler:
-- clang
+- gcc
 c_compiler_version:
-- '10'
+- '8'
 cairo:
 - '1.16'
 channel_sources:
@@ -13,15 +11,19 @@ channel_sources:
 channel_targets:
 - conda-forge main
 cxx_compiler:
-- clangxx
+- gxx
 cxx_compiler_version:
-- '10'
+- '8'
+docker_image:
+- condaforge/linux-anvil-ppc64le
 fortran_compiler:
 - gfortran
 fortran_compiler_version:
-- '7'
+- '8'
 freetype:
 - 2.9.1
+glib:
+- 2.64.6
 gsl:
 - '2.6'
 icu:
@@ -34,22 +36,18 @@ libblas:
 - 3.8 *netlib
 libcurl:
 - '7'
-libiconv:
-- '1.15'
 liblapack:
-- 3.8.0 *netlib
+- 3.8 *netlib
 libpng:
 - '1.6'
 libssh2:
 - '1'
 libtiff:
 - 4.1.0
+libuuid:
+- 2.32.1
 libxml2:
 - '2.9'
-macos_machine:
-- x86_64-apple-darwin13.4.0
-macos_min_version:
-- '10.9'
 ncurses:
 - '6.2'
 pango:
@@ -61,19 +59,17 @@ pin_run_as_build:
     max_pin: x.x
   freetype:
     max_pin: x
-  icu:
-    max_pin: x
   jpeg:
     max_pin: x
   krb5:
     max_pin: x.x
   libcurl:
     max_pin: x
-  libiconv:
-    max_pin: x.x
   libpng:
     max_pin: x.x
   libtiff:
+    max_pin: x
+  libuuid:
     max_pin: x
   libxml2:
     max_pin: x.x
@@ -83,8 +79,6 @@ pin_run_as_build:
     max_pin: x.x
   readline:
     max_pin: x
-  tk:
-    max_pin: x.x
   xz:
     max_pin: x.x
   zlib:
@@ -92,10 +86,12 @@ pin_run_as_build:
 readline:
 - '8.0'
 target_platform:
-- osx-64
-tk:
-- '8.6'
+- linux-ppc64le
 xz:
 - '5.2'
+zip_keys:
+- - c_compiler_version
+  - cxx_compiler_version
+  - fortran_compiler_version
 zlib:
 - '1.2'

--- a/.ci_support/linux_ppc64le_c_compiler_version9cxx_compiler_version9fortran_compiler_version9target_platformlinux-ppc64le.yaml
+++ b/.ci_support/linux_ppc64le_c_compiler_version9cxx_compiler_version9fortran_compiler_version9target_platformlinux-ppc64le.yaml
@@ -1,0 +1,97 @@
+bzip2:
+- '1'
+c_compiler:
+- gcc
+c_compiler_version:
+- '9'
+cairo:
+- '1.16'
+channel_sources:
+- conda-forge,defaults
+channel_targets:
+- conda-forge main
+cxx_compiler:
+- gxx
+cxx_compiler_version:
+- '9'
+docker_image:
+- condaforge/linux-anvil-ppc64le
+fortran_compiler:
+- gfortran
+fortran_compiler_version:
+- '9'
+freetype:
+- 2.9.1
+glib:
+- 2.64.6
+gsl:
+- '2.6'
+icu:
+- '67'
+jpeg:
+- '9'
+krb5:
+- 1.17.1
+libblas:
+- 3.8 *netlib
+libcurl:
+- '7'
+liblapack:
+- 3.8 *netlib
+libpng:
+- '1.6'
+libssh2:
+- '1'
+libtiff:
+- 4.1.0
+libuuid:
+- 2.32.1
+libxml2:
+- '2.9'
+ncurses:
+- '6.2'
+pango:
+- '1.42'
+pin_run_as_build:
+  bzip2:
+    max_pin: x
+  cairo:
+    max_pin: x.x
+  freetype:
+    max_pin: x
+  jpeg:
+    max_pin: x
+  krb5:
+    max_pin: x.x
+  libcurl:
+    max_pin: x
+  libpng:
+    max_pin: x.x
+  libtiff:
+    max_pin: x
+  libuuid:
+    max_pin: x
+  libxml2:
+    max_pin: x.x
+  ncurses:
+    max_pin: x.x
+  pango:
+    max_pin: x.x
+  readline:
+    max_pin: x
+  xz:
+    max_pin: x.x
+  zlib:
+    max_pin: x.x
+readline:
+- '8.0'
+target_platform:
+- linux-ppc64le
+xz:
+- '5.2'
+zip_keys:
+- - c_compiler_version
+  - cxx_compiler_version
+  - fortran_compiler_version
+zlib:
+- '1.2'

--- a/.ci_support/migrations/gcc930.yaml
+++ b/.ci_support/migrations/gcc930.yaml
@@ -1,0 +1,60 @@
+migrator_ts: 1602079781
+
+__migrator:
+  kind:
+    version
+  migration_number: 1
+  build_number: 1
+  override_cbc_keys:
+    - fortran_compiler_stub
+  paused: false
+
+c_compiler_version:            # [unix]
+  - 11                         # [osx and arm64]
+
+  - 10                         # [osx and x86_64]
+  - 10                         # [osx and x86_64]
+
+  - 9                          # [linux64]
+  - 9                          # [aarch64]
+  - 9                          # [ppc64le]
+
+  # we are keeping both versions for a while during the migration
+  # we need to remove 7/8 when the migration is done
+  - 7                          # [linux64]
+  - 7                          # [aarch64]
+  - 8                          # [ppc64le]
+
+cxx_compiler_version:          # [unix]
+  - 11                         # [osx and arm64]
+
+  - 10                         # [osx and x86_64]
+  - 10                         # [osx and x86_64]
+
+  - 9                          # [linux64]
+  - 9                          # [aarch64]
+  - 9                          # [ppc64le]
+
+  # we are keeping both versions for a while during the migration
+  # we need to remove 7/8 when the migration is done
+  - 7                          # [linux64]
+  - 7                          # [aarch64]
+  - 8                          # [ppc64le]
+
+fortran_compiler_version:      # [unix or win64]
+  - 11                         # [osx and arm64]
+
+  - 9                          # [osx and x86_64]
+  - 7                          # [osx and x86_64]
+
+  - 9                          # [linux64]
+  - 9                          # [aarch64]
+  - 9                          # [ppc64le]
+
+  # we are keeping both versions for a while during the migration
+  # we need to remove 7/8 when the migration is done
+  - 7                          # [linux64]
+  - 7                          # [aarch64]
+  - 8                          # [ppc64le]
+
+  - 5                          # [win64]

--- a/.ci_support/migrations/glib2646.yaml
+++ b/.ci_support/migrations/glib2646.yaml
@@ -1,0 +1,13 @@
+migrator_ts: 1
+__migrator:
+  kind:
+    version
+  migration_number:
+    1
+  build_number:
+    1
+
+glib:
+  - 2.64.6
+libglib:
+  - 2.64.6

--- a/.ci_support/migrations/icu67.yaml
+++ b/.ci_support/migrations/icu67.yaml
@@ -1,7 +1,0 @@
-__migrator:
-  build_number: 1
-  kind: version
-  migration_number: 1
-icu:
-- '67'
-migrator_ts: 1588861771.6052268

--- a/.ci_support/migrations/krb51171.yaml
+++ b/.ci_support/migrations/krb51171.yaml
@@ -1,7 +1,0 @@
-__migrator:
-  build_number: 1
-  kind: version
-  migration_number: 1
-krb5:
-- 1.17.1
-migrator_ts: 1584168396.450607

--- a/.ci_support/osx_64_fortran_compiler_version7target_platformosx-64.yaml
+++ b/.ci_support/osx_64_fortran_compiler_version7target_platformosx-64.yaml
@@ -1,0 +1,103 @@
+MACOSX_DEPLOYMENT_TARGET:
+- '10.9'
+bzip2:
+- '1'
+c_compiler:
+- clang
+c_compiler_version:
+- '10'
+cairo:
+- '1.16'
+channel_sources:
+- conda-forge,defaults
+channel_targets:
+- conda-forge main
+cxx_compiler:
+- clangxx
+cxx_compiler_version:
+- '10'
+fortran_compiler:
+- gfortran
+fortran_compiler_version:
+- '7'
+freetype:
+- 2.9.1
+glib:
+- 2.64.6
+gsl:
+- '2.6'
+icu:
+- '67'
+jpeg:
+- '9'
+krb5:
+- 1.17.1
+libblas:
+- 3.8 *netlib
+libcurl:
+- '7'
+libiconv:
+- '1.16'
+liblapack:
+- 3.8 *netlib
+libpng:
+- '1.6'
+libssh2:
+- '1'
+libtiff:
+- 4.1.0
+libxml2:
+- '2.9'
+macos_machine:
+- x86_64-apple-darwin13.4.0
+ncurses:
+- '6.2'
+pango:
+- '1.42'
+pin_run_as_build:
+  bzip2:
+    max_pin: x
+  cairo:
+    max_pin: x.x
+  freetype:
+    max_pin: x
+  jpeg:
+    max_pin: x
+  krb5:
+    max_pin: x.x
+  libcurl:
+    max_pin: x
+  libiconv:
+    max_pin: x.x
+  libpng:
+    max_pin: x.x
+  libtiff:
+    max_pin: x
+  libxml2:
+    max_pin: x.x
+  ncurses:
+    max_pin: x.x
+  pango:
+    max_pin: x.x
+  readline:
+    max_pin: x
+  tk:
+    max_pin: x.x
+  xz:
+    max_pin: x.x
+  zlib:
+    max_pin: x.x
+readline:
+- '8.0'
+target_platform:
+- osx-64
+tk:
+- '8.6'
+xz:
+- '5.2'
+zip_keys:
+- - c_compiler_version
+  - cxx_compiler_version
+  - fortran_compiler_version
+zlib:
+- '1.2'

--- a/.ci_support/osx_64_fortran_compiler_version9target_platformosx-64.yaml
+++ b/.ci_support/osx_64_fortran_compiler_version9target_platformosx-64.yaml
@@ -1,9 +1,11 @@
+MACOSX_DEPLOYMENT_TARGET:
+- '10.9'
 bzip2:
 - '1'
 c_compiler:
-- gcc
+- clang
 c_compiler_version:
-- '8'
+- '10'
 cairo:
 - '1.16'
 channel_sources:
@@ -11,19 +13,17 @@ channel_sources:
 channel_targets:
 - conda-forge main
 cxx_compiler:
-- gxx
+- clangxx
 cxx_compiler_version:
-- '8'
-docker_image:
-- condaforge/linux-anvil-ppc64le
+- '10'
 fortran_compiler:
 - gfortran
 fortran_compiler_version:
-- '8'
+- '9'
 freetype:
 - 2.9.1
 glib:
-- '2.58'
+- 2.64.6
 gsl:
 - '2.6'
 icu:
@@ -36,18 +36,20 @@ libblas:
 - 3.8 *netlib
 libcurl:
 - '7'
+libiconv:
+- '1.16'
 liblapack:
-- 3.8.0 *netlib
+- 3.8 *netlib
 libpng:
 - '1.6'
 libssh2:
 - '1'
 libtiff:
 - 4.1.0
-libuuid:
-- 2.32.1
 libxml2:
 - '2.9'
+macos_machine:
+- x86_64-apple-darwin13.4.0
 ncurses:
 - '6.2'
 pango:
@@ -59,19 +61,17 @@ pin_run_as_build:
     max_pin: x.x
   freetype:
     max_pin: x
-  icu:
-    max_pin: x
   jpeg:
     max_pin: x
   krb5:
     max_pin: x.x
   libcurl:
     max_pin: x
+  libiconv:
+    max_pin: x.x
   libpng:
     max_pin: x.x
   libtiff:
-    max_pin: x
-  libuuid:
     max_pin: x
   libxml2:
     max_pin: x.x
@@ -81,6 +81,8 @@ pin_run_as_build:
     max_pin: x.x
   readline:
     max_pin: x
+  tk:
+    max_pin: x.x
   xz:
     max_pin: x.x
   zlib:
@@ -88,8 +90,14 @@ pin_run_as_build:
 readline:
 - '8.0'
 target_platform:
-- linux-ppc64le
+- osx-64
+tk:
+- '8.6'
 xz:
 - '5.2'
+zip_keys:
+- - c_compiler_version
+  - cxx_compiler_version
+  - fortran_compiler_version
 zlib:
 - '1.2'

--- a/.ci_support/win_64_target_platformwin-64.yaml
+++ b/.ci_support/win_64_target_platformwin-64.yaml
@@ -5,7 +5,7 @@ channel_targets:
 libblas:
 - 3.8 *netlib
 liblapack:
-- 3.8.0 *netlib
+- 3.8 *netlib
 m2w64_c_compiler:
 - m2w64-toolchain
 m2w64_cxx_compiler:

--- a/.drone.yml
+++ b/.drone.yml
@@ -1,6 +1,6 @@
 ---
 kind: pipeline
-name: linux_aarch64_target_platformlinux-aarch64
+name: linux_aarch64_c_compiler_version7cx_hd63e28853d
 
 platform:
   os: linux
@@ -10,11 +10,46 @@ steps:
 - name: Install and build
   image: condaforge/linux-anvil-aarch64
   environment:
-    CONFIG: linux_aarch64_target_platformlinux-aarch64
+    CONFIG: linux_aarch64_c_compiler_version7cxx_compiler_version7fortran_compiler_version7target_platformlinux-aarch64
     UPLOAD_PACKAGES: True
     PLATFORM: linux-aarch64
     BINSTAR_TOKEN:
       from_secret: BINSTAR_TOKEN
+    FEEDSTOCK_TOKEN:
+      from_secret: FEEDSTOCK_TOKEN
+    STAGING_BINSTAR_TOKEN:
+      from_secret: STAGING_BINSTAR_TOKEN
+  commands:
+    - export FEEDSTOCK_ROOT="$DRONE_WORKSPACE"
+    - export RECIPE_ROOT="$FEEDSTOCK_ROOT/recipe"
+    - export CI=drone
+    - export GIT_BRANCH="$DRONE_BRANCH"
+    - export FEEDSTOCK_NAME=$(basename ${DRONE_REPO_NAME})
+    - sed -i '$ichown -R conda:conda "$FEEDSTOCK_ROOT"' /opt/docker/bin/entrypoint
+    - /opt/docker/bin/entrypoint $FEEDSTOCK_ROOT/.scripts/build_steps.sh
+    - echo "Done building"
+
+---
+kind: pipeline
+name: linux_aarch64_c_compiler_version9cx_h7b024028e0
+
+platform:
+  os: linux
+  arch: arm64
+
+steps:
+- name: Install and build
+  image: condaforge/linux-anvil-aarch64
+  environment:
+    CONFIG: linux_aarch64_c_compiler_version9cxx_compiler_version9fortran_compiler_version9target_platformlinux-aarch64
+    UPLOAD_PACKAGES: True
+    PLATFORM: linux-aarch64
+    BINSTAR_TOKEN:
+      from_secret: BINSTAR_TOKEN
+    FEEDSTOCK_TOKEN:
+      from_secret: FEEDSTOCK_TOKEN
+    STAGING_BINSTAR_TOKEN:
+      from_secret: STAGING_BINSTAR_TOKEN
   commands:
     - export FEEDSTOCK_ROOT="$DRONE_WORKSPACE"
     - export RECIPE_ROOT="$FEEDSTOCK_ROOT/recipe"

--- a/.scripts/build_steps.sh
+++ b/.scripts/build_steps.sh
@@ -19,7 +19,7 @@ conda-build:
 
 CONDARC
 
-conda install --yes --quiet conda-forge-ci-setup=3 conda-build pip -c conda-forge
+conda install --yes --quiet "conda-forge-ci-setup=3" conda-build pip -c conda-forge
 
 # set up the condarc
 setup_conda_rc "${FEEDSTOCK_ROOT}" "${RECIPE_ROOT}" "${CONFIG_FILE}"
@@ -37,12 +37,25 @@ source run_conda_forge_build_setup
 # make the build number clobber
 make_build_number "${FEEDSTOCK_ROOT}" "${RECIPE_ROOT}" "${CONFIG_FILE}"
 
-conda build "${RECIPE_ROOT}" -m "${CI_SUPPORT}/${CONFIG}.yaml" \
-    --suppress-variables \
-    --clobber-file "${CI_SUPPORT}/clobber_${CONFIG}.yaml"
 
-if [[ "${UPLOAD_PACKAGES}" != "False" ]]; then
-    upload_package  "${FEEDSTOCK_ROOT}" "${RECIPE_ROOT}" "${CONFIG_FILE}"
+if [[ "${BUILD_WITH_CONDA_DEBUG:-0}" == 1 ]]; then
+    if [[ "x${BUILD_OUTPUT_ID:-}" != "x" ]]; then
+        EXTRA_CB_OPTIONS="${EXTRA_CB_OPTIONS:-} --output-id ${BUILD_OUTPUT_ID}"
+    fi
+    conda debug "${RECIPE_ROOT}" -m "${CI_SUPPORT}/${CONFIG}.yaml" \
+        ${EXTRA_CB_OPTIONS:-} \
+        --clobber-file "${CI_SUPPORT}/clobber_${CONFIG}.yaml"
+    # Drop into an interactive shell
+    /bin/bash
+else
+    conda build "${RECIPE_ROOT}" -m "${CI_SUPPORT}/${CONFIG}.yaml" \
+        --suppress-variables ${EXTRA_CB_OPTIONS:-} \
+        --clobber-file "${CI_SUPPORT}/clobber_${CONFIG}.yaml"
+    validate_recipe_outputs "${FEEDSTOCK_NAME}"
+
+    if [[ "${UPLOAD_PACKAGES}" != "False" ]]; then
+        upload_package --validate --feedstock-name="${FEEDSTOCK_NAME}"  "${FEEDSTOCK_ROOT}" "${RECIPE_ROOT}" "${CONFIG_FILE}"
+    fi
 fi
 
 touch "${FEEDSTOCK_ROOT}/build_artifacts/conda-forge-build-done-${CONFIG}"

--- a/.scripts/run_docker_build.sh
+++ b/.scripts/run_docker_build.sh
@@ -74,7 +74,11 @@ docker run ${DOCKER_RUN_ARGS} \
            -e CI \
            -e FEEDSTOCK_NAME \
            -e CPU_COUNT \
+           -e BUILD_WITH_CONDA_DEBUG \
+           -e BUILD_OUTPUT_ID \
            -e BINSTAR_TOKEN \
+           -e FEEDSTOCK_TOKEN \
+           -e STAGING_BINSTAR_TOKEN \
            $DOCKER_IMAGE \
            bash \
            /home/conda/feedstock_root/${PROVIDER_DIR}/build_steps.sh

--- a/.scripts/run_osx_build.sh
+++ b/.scripts/run_osx_build.sh
@@ -23,7 +23,7 @@ source ${HOME}/miniforge3/etc/profile.d/conda.sh
 conda activate base
 
 echo -e "\n\nInstalling conda-forge-ci-setup=3 and conda-build."
-conda install -n base --quiet --yes conda-forge-ci-setup=3 conda-build pip
+conda install -n base --quiet --yes "conda-forge-ci-setup=3" conda-build pip
 
 
 
@@ -47,9 +47,11 @@ set -e
 
 echo -e "\n\nMaking the build clobber file and running the build."
 make_build_number ./ ./recipe ./.ci_support/${CONFIG}.yaml
-conda build ./recipe -m ./.ci_support/${CONFIG}.yaml --suppress-variables --clobber-file ./.ci_support/clobber_${CONFIG}.yaml
+
+conda build ./recipe -m ./.ci_support/${CONFIG}.yaml --suppress-variables --clobber-file ./.ci_support/clobber_${CONFIG}.yaml ${EXTRA_CB_OPTIONS:-}
+validate_recipe_outputs "${FEEDSTOCK_NAME}"
 
 if [[ "${UPLOAD_PACKAGES}" != "False" ]]; then
   echo -e "\n\nUploading the packages."
-  upload_package  ./ ./recipe ./.ci_support/${CONFIG}.yaml
+  upload_package --validate --feedstock-name="${FEEDSTOCK_NAME}" ./ ./recipe ./.ci_support/${CONFIG}.yaml
 fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,14 +3,15 @@
 
 language: generic
 
-env:
-  global:
-    # The BINSTAR_TOKEN secure variable. This is defined canonically in conda-forge.yml.
-    - secure: "hwRyKuP+NYE7wdeFNYZ283AjwpT076Lu1/RCeT/kvxZEttG6510lPuBNsV0zhjHlkOfXKxEFm4xHtwE3q68Dl2sMGjVX5M+X2m6Pb7Ei1WBAdXOSZW92hsHUWu9v2fVCXa/Les2JTAd8BZRLF0eXUkQ2jg8qaXnSHOXcuzK8W8BBps8rc4nh8qR70aauJdOS0HLKi+zPfEw2pHSZeeMgXpuRumB8InS3OzTQQdoHtZeHakR8DtTW3W+0bzff7FQUPiEYYikgMlXCJLiMLB1CG0+edujagQEfeB3t6AkM+IV1cGBmhlzI5DWZd1O2XQm8kb74trenwEaqLPBcixwq68Z9IHOCH1jPaHIW6euIRRUZcT2fYBf0zeBPV0+XTHml2kXBgPXBMS/WDt+iqeKXmd+WNlR5fW/esxY0VunW82A6G+LTqv3ojkwmGmfLLyD9dp09KuOIgNRGLM2J6gcNZ3LxCERxwJLG3y3lLPJVEozYmJuylPVFCyjkPuT14+MKkPBp2cAeKfwRi3Uczo/lDathKr+wmW9SN48Q9lxp3wOaxqqpGhAuf/NvBQiAN1Xbjf19ZLFnZBIl5gKKUstR1HepDZPY+us1Luyp5P7F1v/wMIYUQ53VP0lUZyA9zPqxAaTfS9nqxfmIn+ETgmdv/dLzvA0OGce2nqTN54hbG6Q="
+
 
 matrix:
   include:
-    - env: CONFIG=linux_ppc64le_target_platformlinux-ppc64le UPLOAD_PACKAGES=True PLATFORM=linux-ppc64le DOCKER_IMAGE=condaforge/linux-anvil-ppc64le
+    - env: CONFIG=linux_ppc64le_c_compiler_version8cxx_compiler_version8fortran_compiler_version8target_platformlinux-ppc64le UPLOAD_PACKAGES=True PLATFORM=linux-ppc64le DOCKER_IMAGE=condaforge/linux-anvil-ppc64le
+      os: linux
+      arch: ppc64le
+
+    - env: CONFIG=linux_ppc64le_c_compiler_version9cxx_compiler_version9fortran_compiler_version9target_platformlinux-ppc64le UPLOAD_PACKAGES=True PLATFORM=linux-ppc64le DOCKER_IMAGE=condaforge/linux-anvil-ppc64le
       os: linux
       arch: ppc64le
 

--- a/LICENSE.txt
+++ b/LICENSE.txt
@@ -1,5 +1,5 @@
 BSD 3-clause license
-Copyright (c) 2015-2019, conda-forge
+Copyright (c) 2015-2020, conda-forge contributors
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without modification, are permitted provided that the following conditions are met:

--- a/README.md
+++ b/README.md
@@ -5,11 +5,9 @@ Home: http://www.r-project.org/
 
 Package license: GPL-2.0-or-later
 
-Feedstock license: BSD-3-Clause
+Feedstock license: [BSD-3-Clause](https://github.com/conda-forge/r-base-feedstock/blob/master/LICENSE.txt)
 
 Summary: R is a free software environment for statistical computing and graphics.
-
-
 
 Current build status
 ====================
@@ -43,38 +41,66 @@ Current build status
         <table>
           <thead><tr><th>Variant</th><th>Status</th></tr></thead>
           <tbody><tr>
-              <td>linux_aarch64_target_platformlinux-aarch64</td>
+              <td>linux_64_c_compiler_version7cxx_compiler_version7fortran_compiler_version7target_platformlinux-64</td>
               <td>
                 <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=984&branchName=master">
-                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/r-base-feedstock?branchName=master&jobName=linux&configuration=linux_aarch64_target_platformlinux-aarch64" alt="variant">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/r-base-feedstock?branchName=master&jobName=linux&configuration=linux_64_c_compiler_version7cxx_compiler_version7fortran_compiler_version7target_platformlinux-64" alt="variant">
                 </a>
               </td>
             </tr><tr>
-              <td>linux_ppc64le_target_platformlinux-ppc64le</td>
+              <td>linux_64_c_compiler_version9cxx_compiler_version9fortran_compiler_version9target_platformlinux-64</td>
               <td>
                 <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=984&branchName=master">
-                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/r-base-feedstock?branchName=master&jobName=linux&configuration=linux_ppc64le_target_platformlinux-ppc64le" alt="variant">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/r-base-feedstock?branchName=master&jobName=linux&configuration=linux_64_c_compiler_version9cxx_compiler_version9fortran_compiler_version9target_platformlinux-64" alt="variant">
                 </a>
               </td>
             </tr><tr>
-              <td>linux_target_platformlinux-64</td>
+              <td>linux_aarch64_c_compiler_version7cxx_compiler_version7fortran_compiler_version7target_platformlinux-aarch64</td>
               <td>
                 <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=984&branchName=master">
-                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/r-base-feedstock?branchName=master&jobName=linux&configuration=linux_target_platformlinux-64" alt="variant">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/r-base-feedstock?branchName=master&jobName=linux&configuration=linux_aarch64_c_compiler_version7cxx_compiler_version7fortran_compiler_version7target_platformlinux-aarch64" alt="variant">
                 </a>
               </td>
             </tr><tr>
-              <td>osx_target_platformosx-64</td>
+              <td>linux_aarch64_c_compiler_version9cxx_compiler_version9fortran_compiler_version9target_platformlinux-aarch64</td>
               <td>
                 <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=984&branchName=master">
-                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/r-base-feedstock?branchName=master&jobName=osx&configuration=osx_target_platformosx-64" alt="variant">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/r-base-feedstock?branchName=master&jobName=linux&configuration=linux_aarch64_c_compiler_version9cxx_compiler_version9fortran_compiler_version9target_platformlinux-aarch64" alt="variant">
                 </a>
               </td>
             </tr><tr>
-              <td>win_target_platformwin-64</td>
+              <td>linux_ppc64le_c_compiler_version8cxx_compiler_version8fortran_compiler_version8target_platformlinux-ppc64le</td>
               <td>
                 <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=984&branchName=master">
-                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/r-base-feedstock?branchName=master&jobName=win&configuration=win_target_platformwin-64" alt="variant">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/r-base-feedstock?branchName=master&jobName=linux&configuration=linux_ppc64le_c_compiler_version8cxx_compiler_version8fortran_compiler_version8target_platformlinux-ppc64le" alt="variant">
+                </a>
+              </td>
+            </tr><tr>
+              <td>linux_ppc64le_c_compiler_version9cxx_compiler_version9fortran_compiler_version9target_platformlinux-ppc64le</td>
+              <td>
+                <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=984&branchName=master">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/r-base-feedstock?branchName=master&jobName=linux&configuration=linux_ppc64le_c_compiler_version9cxx_compiler_version9fortran_compiler_version9target_platformlinux-ppc64le" alt="variant">
+                </a>
+              </td>
+            </tr><tr>
+              <td>osx_64_fortran_compiler_version7target_platformosx-64</td>
+              <td>
+                <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=984&branchName=master">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/r-base-feedstock?branchName=master&jobName=osx&configuration=osx_64_fortran_compiler_version7target_platformosx-64" alt="variant">
+                </a>
+              </td>
+            </tr><tr>
+              <td>osx_64_fortran_compiler_version9target_platformosx-64</td>
+              <td>
+                <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=984&branchName=master">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/r-base-feedstock?branchName=master&jobName=osx&configuration=osx_64_fortran_compiler_version9target_platformosx-64" alt="variant">
+                </a>
+              </td>
+            </tr><tr>
+              <td>win_64_target_platformwin-64</td>
+              <td>
+                <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=984&branchName=master">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/r-base-feedstock?branchName=master&jobName=win&configuration=win_64_target_platformwin-64" alt="variant">
                 </a>
               </td>
             </tr>

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -4,5 +4,5 @@
 
 jobs:
   - template: ./.azure-pipelines/azure-pipelines-linux.yml
-  - template: ./.azure-pipelines/azure-pipelines-osx.yml
   - template: ./.azure-pipelines/azure-pipelines-win.yml
+  - template: ./.azure-pipelines/azure-pipelines-osx.yml

--- a/build-locally.py
+++ b/build-locally.py
@@ -12,6 +12,10 @@ from argparse import ArgumentParser
 def setup_environment(ns):
     os.environ["CONFIG"] = ns.config
     os.environ["UPLOAD_PACKAGES"] = "False"
+    if ns.debug:
+        os.environ["BUILD_WITH_CONDA_DEBUG"] = "1"
+        if ns.output_id:
+            os.environ["BUILD_OUTPUT_ID"] = ns.output_id
 
 
 def run_docker_build(ns):
@@ -51,6 +55,14 @@ def verify_config(ns):
 def main(args=None):
     p = ArgumentParser("build-locally")
     p.add_argument("config", default=None, nargs="?")
+    p.add_argument(
+        "--debug",
+        action="store_true",
+        help="Setup debug environment using `conda debug`",
+    )
+    p.add_argument(
+        "--output-id", help="If running debug, specify the output to setup."
+    )
 
     ns = p.parse_args(args=args)
     verify_config(ns)

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -30,7 +30,7 @@ source:
 
 build:
   merge_build_host: True  # [win]
-  number: 3
+  number: 4
   rpaths:
     - lib/R/lib/
     - lib/
@@ -94,7 +94,7 @@ requirements:
     - {{ native }}libiconv               # [win]
     - libuuid                            # [linux]
     - {{ native }}gmp                    # [win]
-    - glib                               # [linux]
+    - glib                               # [unix]
     - {{ native }}fftw                   # [win]
     - {{ native }}xz                     # [win]
     - {{ native }}mpfr                   # [win]


### PR DESCRIPTION
<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [ ] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [ ] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [ ] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [ ] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->

These are needed to get a version of all of the r-base pinnings that works with the R package rebuilds.