### PR TITLE
Apply migrations to 3.6.x branch too

### DIFF
--- a/conda-forge.yml
+++ b/conda-forge.yml
@@ -2,3 +2,6 @@ build_platform: {osx_arm64: osx_64}
 conda_forge_output_validation: true
 provider: {linux_aarch64: default, linux_ppc64le: default, win: azure}
 test_on_native_only: true
+bot:
+  abi_migration_branches:
+    - "3.6.x"


### PR DESCRIPTION
We still have 3.6 in our build matrix so we should also apply migrations to it. I'm currently running into issues where I have conflicts with e.g. `icu=68` and `r-base=3.6`.

<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [ ] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [ ] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [ ] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [ ] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
