### PR TITLE
Move ABI migrations to 4.0.x branch

### DIFF
--- a/conda-forge.yml
+++ b/conda-forge.yml
@@ -4,4 +4,4 @@ provider: {linux_aarch64: default, linux_ppc64le: default, win: azure}
 test_on_native_only: true
 bot:
   abi_migration_branches:
-    - "3.6.x"
+    - "4.0.x"


### PR DESCRIPTION
Currently, the `pcre2` migration is stalled as we have no migrated `r-base=4.0`.