### PR TITLE
Setup 4.2.x for abi_migration_branches

### DIFF
--- a/.ci_support/linux_64_.yaml
+++ b/.ci_support/linux_64_.yaml
@@ -3,7 +3,7 @@ bzip2:
 c_compiler:
 - gcc
 c_compiler_version:
-- '11'
+- '12'
 cairo:
 - '1'
 cdt_name:
@@ -15,13 +15,13 @@ channel_targets:
 cxx_compiler:
 - gxx
 cxx_compiler_version:
-- '11'
+- '12'
 docker_image:
 - quay.io/condaforge/linux-anvil-cos7-x86_64
 fortran_compiler:
 - gfortran
 fortran_compiler_version:
-- '11'
+- '12'
 freetype:
 - '2'
 glib:
@@ -35,7 +35,7 @@ krb5:
 libblas:
 - 3.9 *netlib
 libcurl:
-- '7'
+- '8'
 libjpeg_turbo:
 - 2.1.5
 liblapack:

--- a/.ci_support/linux_aarch64_.yaml
+++ b/.ci_support/linux_aarch64_.yaml
@@ -5,7 +5,7 @@ bzip2:
 c_compiler:
 - gcc
 c_compiler_version:
-- '11'
+- '12'
 cairo:
 - '1'
 cdt_arch:
@@ -19,13 +19,13 @@ channel_targets:
 cxx_compiler:
 - gxx
 cxx_compiler_version:
-- '11'
+- '12'
 docker_image:
 - quay.io/condaforge/linux-anvil-aarch64
 fortran_compiler:
 - gfortran
 fortran_compiler_version:
-- '11'
+- '12'
 freetype:
 - '2'
 glib:
@@ -39,7 +39,7 @@ krb5:
 libblas:
 - 3.9 *netlib
 libcurl:
-- '7'
+- '8'
 libjpeg_turbo:
 - 2.1.5
 liblapack:

--- a/.ci_support/linux_ppc64le_.yaml
+++ b/.ci_support/linux_ppc64le_.yaml
@@ -3,7 +3,7 @@ bzip2:
 c_compiler:
 - gcc
 c_compiler_version:
-- '11'
+- '12'
 cairo:
 - '1'
 cdt_name:
@@ -15,13 +15,13 @@ channel_targets:
 cxx_compiler:
 - gxx
 cxx_compiler_version:
-- '11'
+- '12'
 docker_image:
 - quay.io/condaforge/linux-anvil-ppc64le
 fortran_compiler:
 - gfortran
 fortran_compiler_version:
-- '11'
+- '12'
 freetype:
 - '2'
 glib:
@@ -35,7 +35,7 @@ krb5:
 libblas:
 - 3.9 *netlib
 libcurl:
-- '7'
+- '8'
 libjpeg_turbo:
 - 2.1.5
 liblapack:

--- a/.ci_support/osx_64_.yaml
+++ b/.ci_support/osx_64_.yaml
@@ -5,7 +5,7 @@ bzip2:
 c_compiler:
 - clang
 c_compiler_version:
-- '14'
+- '15'
 cairo:
 - '1'
 channel_sources:
@@ -15,11 +15,11 @@ channel_targets:
 cxx_compiler:
 - clangxx
 cxx_compiler_version:
-- '14'
+- '15'
 fortran_compiler:
 - gfortran
 fortran_compiler_version:
-- '11'
+- '12'
 freetype:
 - '2'
 glib:
@@ -33,7 +33,7 @@ krb5:
 libblas:
 - 3.9 *netlib
 libcurl:
-- '7'
+- '8'
 libiconv:
 - '1'
 libjpeg_turbo:
@@ -49,7 +49,7 @@ libtiff:
 libxml2:
 - '2.10'
 llvm_openmp:
-- '14'
+- '15'
 macos_machine:
 - x86_64-apple-darwin13.4.0
 ncurses:

--- a/.ci_support/osx_arm64_.yaml
+++ b/.ci_support/osx_arm64_.yaml
@@ -5,7 +5,7 @@ bzip2:
 c_compiler:
 - clang
 c_compiler_version:
-- '14'
+- '15'
 cairo:
 - '1'
 channel_sources:
@@ -15,11 +15,11 @@ channel_targets:
 cxx_compiler:
 - clangxx
 cxx_compiler_version:
-- '14'
+- '15'
 fortran_compiler:
 - gfortran
 fortran_compiler_version:
-- '11'
+- '12'
 freetype:
 - '2'
 glib:
@@ -33,7 +33,7 @@ krb5:
 libblas:
 - 3.9 *netlib
 libcurl:
-- '7'
+- '8'
 libiconv:
 - '1'
 libjpeg_turbo:
@@ -49,7 +49,7 @@ libtiff:
 libxml2:
 - '2.10'
 llvm_openmp:
-- '14'
+- '15'
 macos_machine:
 - arm64-apple-darwin20.0.0
 ncurses:

--- a/conda-forge.yml
+++ b/conda-forge.yml
@@ -3,6 +3,7 @@ azure:
 bot:
   abi_migration_branches:
   - 4.1.x
+  - 4.2.x
 build_platform:
   osx_arm64: osx_64
 conda_build:

--- a/recipe/0001-Darwin-Remove-unicode-elipsis-character-from-grDevic.patch
+++ b/recipe/0001-Darwin-Remove-unicode-elipsis-character-from-grDevic.patch
@@ -1,7 +1,7 @@
-From 047aecc647a6ea4a90e5464b81a5940c8e5ee6d6 Mon Sep 17 00:00:00 2001
+From 169e5467a5b27d0fe9c5ad460d04995697e5f8d3 Mon Sep 17 00:00:00 2001
 From: Ray Donnelly <mingw.android@gmail.com>
 Date: Tue, 2 Jan 2018 16:17:34 +0000
-Subject: [PATCH 01/16] Darwin: Remove unicode elipsis character from grDevice
+Subject: [PATCH 01/17] Darwin: Remove unicode elipsis character from grDevice
  "Page Setup..." menu entry
 
 ---
@@ -9,7 +9,7 @@ Subject: [PATCH 01/16] Darwin: Remove unicode elipsis character from grDevice
  1 file changed, 1 insertion(+), 1 deletion(-)
 
 diff --git a/src/library/grDevices/src/qdCocoa.m b/src/library/grDevices/src/qdCocoa.m
-index 825e07c..63b9b10 100644
+index 825e07c1..63b9b10c 100644
 --- a/src/library/grDevices/src/qdCocoa.m
 +++ b/src/library/grDevices/src/qdCocoa.m
 @@ -130,7 +130,7 @@ static QuartzFunctions_t *qf;
@@ -21,6 +21,3 @@ index 825e07c..63b9b10 100644
  	    menuItem = [[NSMenuItem alloc] initWithTitle:@"Print" action:@selector(printDocument:) keyEquivalent:@"p"]; [menu addItem:menuItem]; [menuItem release];   
  	    
              menuItem = [[NSMenuItem alloc] initWithTitle:[menu title] action:nil keyEquivalent:@""]; /* the "Quartz" item in the main menu */
--- 
-2.34.1
-

--- a/recipe/0002-Fix-trio-config.h-include-depth-issue.patch
+++ b/recipe/0002-Fix-trio-config.h-include-depth-issue.patch
@@ -1,14 +1,14 @@
-From 295501726d5ef003131e52af6cbc282142c67a52 Mon Sep 17 00:00:00 2001
+From bd8e0aaa7730e421c185dcb19b9dc2bfd4fc658b Mon Sep 17 00:00:00 2001
 From: Ray Donnelly <mingw.android@gmail.com>
 Date: Wed, 15 Dec 2021 07:32:32 +0100
-Subject: [PATCH 02/16] Fix trio config.h include depth issue
+Subject: [PATCH 02/17] Fix trio config.h include depth issue
 
 ---
  src/extra/trio/Makefile.win | 2 +-
  1 file changed, 1 insertion(+), 1 deletion(-)
 
 diff --git a/src/extra/trio/Makefile.win b/src/extra/trio/Makefile.win
-index 5a8abf8..935ba50 100644
+index 5a8abf82..935ba501 100644
 --- a/src/extra/trio/Makefile.win
 +++ b/src/extra/trio/Makefile.win
 @@ -2,7 +2,7 @@
@@ -20,6 +20,3 @@ index 5a8abf8..935ba50 100644
  
  CPPFLAGS = -I../../include -I../../main
  
--- 
-2.34.1
-

--- a/recipe/0003-Win32-Do-not-link-static-libgcc.patch
+++ b/recipe/0003-Win32-Do-not-link-static-libgcc.patch
@@ -1,14 +1,14 @@
-From 4b9f9c7eadb839835e3a50315c0f52e935c8222b Mon Sep 17 00:00:00 2001
+From 29e2937d5412098801f6bdf654782b0534116193 Mon Sep 17 00:00:00 2001
 From: Ray Donnelly <mingw.android@gmail.com>
 Date: Tue, 2 Jan 2018 15:40:19 +0000
-Subject: [PATCH 03/16] Win32: Do not link -static-libgcc
+Subject: [PATCH 03/17] Win32: Do not link -static-libgcc
 
 ---
  src/gnuwin32/fixed/etc/Makeconf | 4 ++--
  1 file changed, 2 insertions(+), 2 deletions(-)
 
 diff --git a/src/gnuwin32/fixed/etc/Makeconf b/src/gnuwin32/fixed/etc/Makeconf
-index d54c158..b8ac01a 100644
+index 4b4bdcca..ff253442 100644
 --- a/src/gnuwin32/fixed/etc/Makeconf
 +++ b/src/gnuwin32/fixed/etc/Makeconf
 @@ -11,8 +11,8 @@ else
@@ -20,8 +20,5 @@ index d54c158..b8ac01a 100644
 +DLLFLAGS+= 
 +LINKFLAGS+= 
  
- ## The rtools40 installer sets RTOOLS40_HOME, default to standard install path
- RTOOLS40_HOME ?= c:/rtools40
--- 
-2.34.1
-
+ 
+ ## Things which are substituted by fixed/Makefile (and also -O3 -> -O2)

--- a/recipe/0004-Win32-Extend-sqrt-NA_real_-hack-to-all-GCC-versions.patch
+++ b/recipe/0004-Win32-Extend-sqrt-NA_real_-hack-to-all-GCC-versions.patch
@@ -1,7 +1,7 @@
-From 46b07fcb6a671ea6e9bcf8f03442511997ee5e32 Mon Sep 17 00:00:00 2001
+From f6a91dc06310a0d735e6ea28f91ab208924d0231 Mon Sep 17 00:00:00 2001
 From: Ray Donnelly <mingw.android@gmail.com>
 Date: Tue, 2 Jan 2018 15:42:00 +0000
-Subject: [PATCH 04/16] Win32: Extend sqrt NA_real_ hack to all GCC versions
+Subject: [PATCH 04/17] Win32: Extend sqrt NA_real_ hack to all GCC versions
 
 Also fix for GCC 5.3 ISNAN(int) emitting UD2 insn
 ---
@@ -9,10 +9,10 @@ Also fix for GCC 5.3 ISNAN(int) emitting UD2 insn
  1 file changed, 2 insertions(+), 3 deletions(-)
 
 diff --git a/src/main/eval.c b/src/main/eval.c
-index f4dff54..bfd4e83 100644
+index 10889523..2e1bdfae 100644
 --- a/src/main/eval.c
 +++ b/src/main/eval.c
-@@ -4563,9 +4563,8 @@ static SEXP cmp_arith2(SEXP call, int opval, SEXP opsym, SEXP x, SEXP y,
+@@ -4583,9 +4583,8 @@ static SEXP cmp_arith2(SEXP call, int opval, SEXP opsym, SEXP x, SEXP y,
     called with NA_real_. Not sure this is a bug in the Windows
     toolchain or in our expectations, but these defines attempt to work
     around this. */
@@ -24,6 +24,3 @@ index f4dff54..bfd4e83 100644
  #else
  # define R_sqrt sqrt
  #endif
--- 
-2.34.1
-

--- a/recipe/0005-Win32-Prevent-conversion-of-R_ARCH-to-abs-Windows-pa.patch
+++ b/recipe/0005-Win32-Prevent-conversion-of-R_ARCH-to-abs-Windows-pa.patch
@@ -1,17 +1,17 @@
-From a0f9a4d1d27487d6961464c88f45a5a0079027a9 Mon Sep 17 00:00:00 2001
+From 9dacf3505745b4db6187413cc521f11ace0a43b5 Mon Sep 17 00:00:00 2001
 From: Ray Donnelly <mingw.android@gmail.com>
 Date: Wed, 15 Dec 2021 07:35:00 +0100
-Subject: [PATCH 05/16] Win32: Prevent conversion of R_ARCH to abs Windows path
+Subject: [PATCH 05/17] Win32: Prevent conversion of R_ARCH to abs Windows path
 
 ---
  src/main/main.c | 28 ++++++++++++++++++++++++++++
  1 file changed, 28 insertions(+)
 
 diff --git a/src/main/main.c b/src/main/main.c
-index a2e3f75..fa87813 100644
+index e1ed38b0..89412668 100644
 --- a/src/main/main.c
 +++ b/src/main/main.c
-@@ -842,6 +842,34 @@ void setup_Rmainloop(void)
+@@ -841,6 +841,34 @@ void setup_Rmainloop(void)
  	    snprintf(deferred_warnings[ndeferred_warnings++], 250,
  		     "Setting LC_TIME=%.200s failed\n", p);
  
@@ -46,6 +46,3 @@ index a2e3f75..fa87813 100644
  	/* We set R_ARCH here: Unix does it in the shell front-end */
  	char Rarch[30];
  	strcpy(Rarch, "R_ARCH=/");
--- 
-2.34.1
-

--- a/recipe/0006-Darwin-Avoid-setting-DYLD_FALLBACK_LIBRARY_PATH.patch
+++ b/recipe/0006-Darwin-Avoid-setting-DYLD_FALLBACK_LIBRARY_PATH.patch
@@ -1,7 +1,7 @@
-From 6343b5893b9393c59a615803257b1fd6a336e5a1 Mon Sep 17 00:00:00 2001
+From b7689a6a98ff753b7fc180cbfc024955400f669e Mon Sep 17 00:00:00 2001
 From: Ray Donnelly <mingw.android@gmail.com>
 Date: Tue, 2 Jan 2018 15:47:26 +0000
-Subject: [PATCH 06/16] Darwin: Avoid setting DYLD_FALLBACK_LIBRARY_PATH
+Subject: [PATCH 06/17] Darwin: Avoid setting DYLD_FALLBACK_LIBRARY_PATH
 
 Since it does nothing these days (you should use -Wl,-rpath,${PREFIX}/lib instead).
 ---
@@ -10,10 +10,10 @@ Since it does nothing these days (you should use -Wl,-rpath,${PREFIX}/lib instea
  2 files changed, 2 insertions(+), 2 deletions(-)
 
 diff --git a/configure b/configure
-index 30d632b..e55984a 100755
+index f30284e3..b9201e7a 100755
 --- a/configure
 +++ b/configure
-@@ -24006,7 +24006,7 @@ ac_compiler_gnu=$ac_cv_c_compiler_gnu
+@@ -24002,7 +24002,7 @@ ac_compiler_gnu=$ac_cv_c_compiler_gnu
  R_LD_LIBRARY_PATH_save=${R_LD_LIBRARY_PATH}
  R_LD_LIBRARY_PATH=
  case "${host_os}" in
@@ -23,10 +23,10 @@ index 30d632b..e55984a 100755
      ## that the linker can add library's path to the binary at link time.
      ## This allows the dyld to find libraries even without xx_LIBRARY_PATH.
 diff --git a/configure.ac b/configure.ac
-index 5ef8269..200a740 100644
+index e52037ab..1d0c3ce9 100644
 --- a/configure.ac
 +++ b/configure.ac
-@@ -808,7 +808,7 @@ AC_SUBST(LIBTOOL_DEPS)
+@@ -806,7 +806,7 @@ AC_SUBST(LIBTOOL_DEPS)
  R_LD_LIBRARY_PATH_save=${R_LD_LIBRARY_PATH}
  R_LD_LIBRARY_PATH=
  case "${host_os}" in
@@ -35,6 +35,3 @@ index 5ef8269..200a740 100644
      ## Darwin provides a full path in the ID of each library such 
      ## that the linker can add library's path to the binary at link time.
      ## This allows the dyld to find libraries even without xx_LIBRARY_PATH.
--- 
-2.34.1
-

--- a/recipe/0007-Use-AC_SEARCH_LIBS-to-search-for-ncursesw-then-ncurs.patch
+++ b/recipe/0007-Use-AC_SEARCH_LIBS-to-search-for-ncursesw-then-ncurs.patch
@@ -1,18 +1,18 @@
-From a7e01d57363e2dc3042d789cf9ed066fa882de2a Mon Sep 17 00:00:00 2001
+From 1e36c90bb4ddefc02ca5b1eb2a11ef1b20e10ec3 Mon Sep 17 00:00:00 2001
 From: Ray Donnelly <mingw.android@gmail.com>
 Date: Wed, 15 Dec 2021 09:24:02 +0100
-Subject: [PATCH 07/16] Use AC_SEARCH_LIBS to search for ncursesw then ncurses
+Subject: [PATCH 07/17] Use AC_SEARCH_LIBS to search for ncursesw then ncurses
 
 ---
- configure    | 58 +++++++++++++++++++++++++++++++++-------------------
+ configure    | 56 +++++++++++++++++++++++++++++++++-------------------
  configure.ac |  2 +-
- 2 files changed, 38 insertions(+), 22 deletions(-)
+ 2 files changed, 37 insertions(+), 21 deletions(-)
 
 diff --git a/configure b/configure
-index d2be94f..d56ca86 100755
+index b9201e7a..41c1debe 100755
 --- a/configure
 +++ b/configure
-@@ -24351,43 +24351,59 @@ fi
+@@ -24352,43 +24352,59 @@ fi
    if test "${use_readline}" = no; then
      ## only need ncurses if libreadline is not statically linked against it
      unset ac_cv_lib_readline_rl_callback_read_char
@@ -93,7 +93,7 @@ index d2be94f..d56ca86 100755
  else $as_nop
    { printf "%s\n" "$as_me:${as_lineno-$LINENO}: checking for main in -ltinfo" >&5
 diff --git a/configure.ac b/configure.ac
-index 9ce4b77..96cea1f 100644
+index 1d0c3ce9..372daaa4 100644
 --- a/configure.ac
 +++ b/configure.ac
 @@ -882,7 +882,7 @@ if test "${use_readline}" = yes; then

--- a/recipe/0008-Linux-Do-not-modify-LD_LIBRARY_PATH.patch
+++ b/recipe/0008-Linux-Do-not-modify-LD_LIBRARY_PATH.patch
@@ -1,7 +1,7 @@
-From c793762a3d18b2505092c4c0a29c9e37acf1a0bf Mon Sep 17 00:00:00 2001
+From 4a99867236c95ce67d233d83165c2a096a0bd4d5 Mon Sep 17 00:00:00 2001
 From: Ray Donnelly <mingw.android@gmail.com>
 Date: Tue, 2 Jan 2018 15:51:41 +0000
-Subject: [PATCH 08/16] Linux: Do not modify LD_LIBRARY_PATH
+Subject: [PATCH 08/17] Linux: Do not modify LD_LIBRARY_PATH
 
 ---
  Makeconf.in     |  3 ++-
@@ -11,10 +11,10 @@ Subject: [PATCH 08/16] Linux: Do not modify LD_LIBRARY_PATH
  4 files changed, 30 insertions(+), 5 deletions(-)
 
 diff --git a/Makeconf.in b/Makeconf.in
-index 6b2a680..fb70773 100644
+index 2797e5c9..cee14963 100644
 --- a/Makeconf.in
 +++ b/Makeconf.in
-@@ -66,7 +66,8 @@ MAIN_CFLAGS = @MAIN_CFLAGS@
+@@ -67,7 +67,8 @@ MAIN_CFLAGS = @MAIN_CFLAGS@
  MAIN_FFLAGS = @MAIN_FFLAGS@
  MAIN_LD = @MAIN_LD@@BUILD_LTO_TRUE@ $(CFLAGS) $(CPICFLAGS) @LTO_LD@
  MAIN_LDFLAGS = @MAIN_LDFLAGS@ @WANT_R_SHLIB_FALSE@ @USE_EXPORTFILES_TRUE@ -Wl,-bE:$(top_builddir)/etc/R.exp
@@ -25,10 +25,10 @@ index 6b2a680..fb70773 100644
  MKINSTALLDIRS = @R_SHELL@ $(top_srcdir)/src/scripts/mkinstalldirs.in
  NOTANGLE = @NOTANGLE@
 diff --git a/configure.ac b/configure.ac
-index 55a5f42..b92b61e 100644
+index 372daaa4..9219aa50 100644
 --- a/configure.ac
 +++ b/configure.ac
-@@ -798,7 +798,7 @@ AC_SUBST(LIBTOOL_DEPS)
+@@ -796,7 +796,7 @@ AC_SUBST(LIBTOOL_DEPS)
  
  ### * Checks for libraries.
  
@@ -37,7 +37,7 @@ index 55a5f42..b92b61e 100644
  ## <FIXME>
  ## What is this doing *HERE*?
  ## Should be needed for tests using AC_RUN_IFELSE()?
-@@ -825,6 +825,7 @@ case "${host_os}" in
+@@ -823,6 +823,7 @@ case "${host_os}" in
          -L*)
  	  lib=`echo ${arg} | sed "s/^-L//"`
  	  R_SH_VAR_ADD(R_LD_LIBRARY_PATH, [${lib}], [${PATH_SEPARATOR}])
@@ -45,7 +45,7 @@ index 55a5f42..b92b61e 100644
  	  ;;
        esac
      done
-@@ -844,13 +845,20 @@ case "${host_os}" in
+@@ -842,13 +843,20 @@ case "${host_os}" in
      Rshlibpath_var=${shlibpath_var}
  esac
  AC_SUBST(shlibpath_var)
@@ -68,7 +68,7 @@ index 55a5f42..b92b61e 100644
  AC_SUBST(Rshlibpath_var)
  
  ## record how to strip shared/dynamic libraries.
-@@ -1762,6 +1770,7 @@ AM_CONDITIONAL(DYLIB_UNDEFINED_ALLOWED, [test "x${dylib_undefined_allowed}" = xy
+@@ -1775,6 +1783,7 @@ AM_CONDITIONAL(DYLIB_UNDEFINED_ALLOWED, [test "x${dylib_undefined_allowed}" = xy
  
  AC_SUBST(MAIN_LD)
  AC_SUBST(MAIN_LDFLAGS)
@@ -77,10 +77,10 @@ index 55a5f42..b92b61e 100644
  AC_SUBST(CXXPICFLAGS)
  AC_SUBST(DYLIB_LD)
 diff --git a/etc/Makeconf.in b/etc/Makeconf.in
-index 0ceb75d..2e79884 100644
+index eb262231..8d79d4e7 100644
 --- a/etc/Makeconf.in
 +++ b/etc/Makeconf.in
-@@ -88,7 +88,8 @@ LTO_FC_OPT = @LTO_FC@
+@@ -89,7 +89,8 @@ LTO_FC_OPT = @LTO_FC@
  ## needed to build applications linking to static libR
  MAIN_LD = @MAIN_LD@
  MAIN_LDFLAGS = @MAIN_LDFLAGS@
@@ -91,7 +91,7 @@ index 0ceb75d..2e79884 100644
  NM = @NM@
  OBJC = @OBJC@
 diff --git a/etc/ldpaths.in b/etc/ldpaths.in
-index 314d364..3fb5331 100644
+index 314d364f..3fb5331f 100644
 --- a/etc/ldpaths.in
 +++ b/etc/ldpaths.in
 @@ -1,3 +1,17 @@
@@ -112,6 +112,3 @@ index 314d364..3fb5331 100644
  : ${JAVA_HOME=@JAVA_HOME@}
  : ${R_JAVA_LD_LIBRARY_PATH=@R_JAVA_LD_LIBRARY_PATH@}
  if test -n "@R_LD_LIBRARY_PATH@"; then
--- 
-2.34.1
-

--- a/recipe/0009-javareconf-Do-not-fail-on-compile-fail.patch
+++ b/recipe/0009-javareconf-Do-not-fail-on-compile-fail.patch
@@ -1,14 +1,14 @@
-From cb58f265c082a74918884dbf6802d86d0db1a24b Mon Sep 17 00:00:00 2001
+From 47d5c097e380158204cd812f086213a56fc62e68 Mon Sep 17 00:00:00 2001
 From: Ray Donnelly <mingw.android@gmail.com>
 Date: Tue, 2 Jan 2018 15:53:45 +0000
-Subject: [PATCH 09/16] javareconf: Do not fail on compile fail
+Subject: [PATCH 09/17] javareconf: Do not fail on compile fail
 
 ---
  src/scripts/javareconf.in | 14 ++++++++++----
  1 file changed, 10 insertions(+), 4 deletions(-)
 
 diff --git a/src/scripts/javareconf.in b/src/scripts/javareconf.in
-index ff4724a..e9472b9 100644
+index 2bf0537a..63cce1a0 100644
 --- a/src/scripts/javareconf.in
 +++ b/src/scripts/javareconf.in
 @@ -347,10 +347,16 @@ ${R_HOME}/bin/R CMD SHLIB conftest.c
@@ -32,6 +32,3 @@ index ff4724a..e9472b9 100644
  fi
  
  rm -f conftest.c conftest.o conftest.so Makevars
--- 
-2.34.1
-

--- a/recipe/0010-Revert-part-of-9b818c6dc00143ff18775a4015a3f43b5196f.patch
+++ b/recipe/0010-Revert-part-of-9b818c6dc00143ff18775a4015a3f43b5196f.patch
@@ -1,7 +1,7 @@
-From f5c1dbed601028fb92ca67410bad103c89e23782 Mon Sep 17 00:00:00 2001
+From 484f50672c088493437cd6aff07e2bac4c5ebcf9 Mon Sep 17 00:00:00 2001
 From: Ray Donnelly <mingw.android@gmail.com>
 Date: Sun, 29 Apr 2018 19:27:02 +0100
-Subject: [PATCH 10/16] Revert part of 9b818c6dc00143ff18775a4015a3f43b5196fa31
+Subject: [PATCH 10/17] Revert part of 9b818c6dc00143ff18775a4015a3f43b5196fa31
  (support for old Java on macOS)
 
 ---
@@ -9,7 +9,7 @@ Subject: [PATCH 10/16] Revert part of 9b818c6dc00143ff18775a4015a3f43b5196fa31
  1 file changed, 17 insertions(+)
 
 diff --git a/src/scripts/javareconf.in b/src/scripts/javareconf.in
-index e9472b9..a59e77a 100644
+index 63cce1a0..8a6c6f9c 100644
 --- a/src/scripts/javareconf.in
 +++ b/src/scripts/javareconf.in
 @@ -199,6 +199,23 @@ custom_JAVA_CPPFLAGS="${JAVA_CPPFLAGS}"
@@ -36,6 +36,3 @@ index e9472b9..a59e77a 100644
  # sys-dependent tweaks to JNI flags -- Darwin ones removed for R 3.5
  
  ## we now look for a path to put in R_LD_LIBRARY_PATH which will
--- 
-2.34.1
-

--- a/recipe/0011-javareconf-macOS-Continue-to-allow-system-Java-lt-9-.patch
+++ b/recipe/0011-javareconf-macOS-Continue-to-allow-system-Java-lt-9-.patch
@@ -1,7 +1,7 @@
-From 19543516783a98305dcb60459a93afd45e4391fc Mon Sep 17 00:00:00 2001
+From e76dbb09e2ef44fbe15ae8472404aa1b440ad4f4 Mon Sep 17 00:00:00 2001
 From: Ray Donnelly <mingw.android@gmail.com>
 Date: Sun, 7 Jan 2018 11:35:05 +0000
-Subject: [PATCH 11/16] javareconf (macOS): Continue to allow system Java lt 9
+Subject: [PATCH 11/17] javareconf (macOS): Continue to allow system Java lt 9
  to be detected as such
 
 Java 9 is for macOS 10.10 and above, we still support 10.9
@@ -25,7 +25,7 @@ is 32-bit only and jni.h does not get found without JNI cpp flags being set.
  1 file changed, 1 insertion(+), 1 deletion(-)
 
 diff --git a/src/scripts/javareconf.in b/src/scripts/javareconf.in
-index a59e77a..b627966 100644
+index 8a6c6f9c..a6e34098 100644
 --- a/src/scripts/javareconf.in
 +++ b/src/scripts/javareconf.in
 @@ -204,7 +204,7 @@ hostos=`uname 2>/dev/null`
@@ -37,6 +37,3 @@ index a59e77a..b627966 100644
       if test "${pref}" = "${JAVA_HOME}"; then
         echo "System Java on macOS"
         JAVA_CPPFLAGS="-I/System/Library/Frameworks/JavaVM.framework/Headers"
--- 
-2.34.1
-

--- a/recipe/0013-Add-luuid-to-X_PRE_LIBS.patch
+++ b/recipe/0013-Add-luuid-to-X_PRE_LIBS.patch
@@ -1,17 +1,17 @@
-From 9c541630cd86796700b50e6d94ecae3ad7939935 Mon Sep 17 00:00:00 2001
+From 8c72901e9e8f486143e70706d798ed66e6b24237 Mon Sep 17 00:00:00 2001
 From: Ray Donnelly <mingw.android@gmail.com>
 Date: Fri, 1 Jun 2018 23:26:13 +0100
-Subject: [PATCH 13/16] Add -luuid to X_PRE_LIBS
+Subject: [PATCH 13/17] Add -luuid to X_PRE_LIBS
 
 ---
  configure | 2 +-
  1 file changed, 1 insertion(+), 1 deletion(-)
 
 diff --git a/configure b/configure
-index 3b5b5d6..00f30b2 100755
+index 41c1debe..75fbbe4a 100755
 --- a/configure
 +++ b/configure
-@@ -45248,7 +45248,7 @@ fi
+@@ -45407,7 +45407,7 @@ fi
  printf "%s\n" "$ac_cv_lib_ICE_IceConnectionNumber" >&6; }
  if test "x$ac_cv_lib_ICE_IceConnectionNumber" = xyes
  then :
@@ -20,6 +20,3 @@ index 3b5b5d6..00f30b2 100755
  fi
  
    LDFLAGS=$ac_save_LDFLAGS
--- 
-2.34.1
-

--- a/recipe/0014-link-Xt-to-uuid.patch
+++ b/recipe/0014-link-Xt-to-uuid.patch
@@ -1,17 +1,17 @@
-From 89af2dc803f45ecb5a876c0dc6e417c2b93dbdf4 Mon Sep 17 00:00:00 2001
+From c14cbd3072ec056b3925943cc9155208da7b1e78 Mon Sep 17 00:00:00 2001
 From: Ray Donnelly <mingw.android@gmail.com>
 Date: Tue, 2 Oct 2018 10:55:37 +0100
-Subject: [PATCH 14/16] link Xt to uuid
+Subject: [PATCH 14/17] link Xt to uuid
 
 ---
  m4/R.m4 | 4 ++--
  1 file changed, 2 insertions(+), 2 deletions(-)
 
 diff --git a/m4/R.m4 b/m4/R.m4
-index f6e3835..81bf493 100644
+index 55ace6ac..3eda3f99 100644
 --- a/m4/R.m4
 +++ b/m4/R.m4
-@@ -1653,7 +1653,7 @@ if test -z "${no_x}"; then
+@@ -1659,7 +1659,7 @@ if test -z "${no_x}"; then
    CPPFLAGS="${r_save_CPPFLAGS}"
    if test "${ac_cv_header_X11_Intrinsic_h}" = yes ; then
      AC_CHECK_LIB(Xt, XtToolkitInitialize, [have_Xt=yes], [have_Xt=no],
@@ -20,7 +20,7 @@ index f6e3835..81bf493 100644
      if test "${have_Xt}" = yes; then
        use_X11="yes"
      fi
-@@ -1663,7 +1663,7 @@ if test "x${use_X11}" = "xyes"; then
+@@ -1669,7 +1669,7 @@ if test "x${use_X11}" = "xyes"; then
    AC_DEFINE(HAVE_X11, 1,
              [Define if you have the X11 headers and libraries, and want
               the X11 GUI to be built.])
@@ -29,6 +29,3 @@ index f6e3835..81bf493 100644
  else
    if test "x${with_x}" != "xno"; then
      AC_MSG_ERROR(
--- 
-2.34.1
-

--- a/recipe/0015-Check-for-changes-then-forcibly-mv-in-javareconf.in.patch
+++ b/recipe/0015-Check-for-changes-then-forcibly-mv-in-javareconf.in.patch
@@ -1,4 +1,4 @@
-From b91e0a5241faaf4b87d97f556f37c2709f34c651 Mon Sep 17 00:00:00 2001
+From 74f48c24834aabc0cab26fbbee2d6f3116abdc9a Mon Sep 17 00:00:00 2001
 From: Marcel Bargull <marcel.bargull@udo.edu>
 Date: Wed, 15 Dec 2021 09:40:05 +0100
 Subject: [PATCH 15/16] Check for changes then forcibly mv in javareconf.in
@@ -8,7 +8,7 @@ Subject: [PATCH 15/16] Check for changes then forcibly mv in javareconf.in
  1 file changed, 9 insertions(+), 7 deletions(-)
 
 diff --git a/src/scripts/javareconf.in b/src/scripts/javareconf.in
-index b627966..5a75896 100644
+index a6e34098..8be32830 100644
 --- a/src/scripts/javareconf.in
 +++ b/src/scripts/javareconf.in
 @@ -419,13 +419,15 @@ else
@@ -34,6 +34,3 @@ index b627966..5a75896 100644
  done
  
  echo "Done."
--- 
-2.34.1
-

--- a/recipe/0016-Use-LAPACK_LDFLAGS-in-Rlapack_la_LIBADD.patch
+++ b/recipe/0016-Use-LAPACK_LDFLAGS-in-Rlapack_la_LIBADD.patch
@@ -1,14 +1,14 @@
-From f24fbd0c19d1e6b6ded30eed1632205f62599a30 Mon Sep 17 00:00:00 2001
+From b1796195e552e5da5ebb8e61188d99a92ca8a58d Mon Sep 17 00:00:00 2001
 From: Ray Donnelly <mingw.android@gmail.com>
 Date: Sat, 27 Apr 2019 00:36:24 +0100
-Subject: [PATCH 16/16] Use LAPACK_LDFLAGS in Rlapack_la_LIBADD
+Subject: [PATCH 16/17] Use LAPACK_LDFLAGS in Rlapack_la_LIBADD
 
 ---
  src/modules/lapack/Makefile.in | 2 +-
  1 file changed, 1 insertion(+), 1 deletion(-)
 
 diff --git a/src/modules/lapack/Makefile.in b/src/modules/lapack/Makefile.in
-index 4a5e1d5..a351a53 100644
+index 4a5e1d5c..a351a531 100644
 --- a/src/modules/lapack/Makefile.in
 +++ b/src/modules/lapack/Makefile.in
 @@ -48,7 +48,7 @@ Rlapack_la_OBJECTS = $(LIBOBJECTS)
@@ -20,6 +20,3 @@ index 4a5e1d5..a351a53 100644
  
  ALL_CFLAGS = $(ALL_CFLAGS_LO)
  ALL_FFLAGS = $(ALL_FFLAGS_LO)
--- 
-2.34.1
-

--- a/recipe/0017-allow-libcurl-8-as-its-API-ABI-is-said-to-be-unchang.patch
+++ b/recipe/0017-allow-libcurl-8-as-its-API-ABI-is-said-to-be-unchang.patch
@@ -1,0 +1,120 @@
+From 3f4660a8235cae28c53a88af00ae06d71b7f550f Mon Sep 17 00:00:00 2001
+From: ripley <ripley@00db46b3-68df-0310-9c12-caf00c1e9a41>
+Date: Sat, 25 Mar 2023 09:01:30 +0000
+Subject: [PATCH 17/17] allow libcurl 8 as its API/ABI is said to be unchanged
+
+git-svn-id: https://svn.r-project.org/R/trunk@84049 00db46b3-68df-0310-9c12-caf00c1e9a41
+
+another (inessential) tweak for libcurl 8
+
+git-svn-id: https://svn.r-project.org/R/trunk@84229 00db46b3-68df-0310-9c12-caf00c1e9a41
+
+a better version of r84229
+
+git-svn-id: https://svn.r-project.org/R/trunk@84232 00db46b3-68df-0310-9c12-caf00c1e9a41
+
+Tweak curl version conditions for TCP_KEEPALIVE (PR#18497).
+
+git-svn-id: https://svn.r-project.org/R/trunk@84247 00db46b3-68df-0310-9c12-caf00c1e9a41
+
+Co-authored-by: kalibera <kalibera@00db46b3-68df-0310-9c12-caf00c1e9a41>
+---
+ configure                      |  6 +++---
+ doc/manual/R-admin.texi        | 13 ++++++-------
+ m4/R.m4                        |  4 ++--
+ src/modules/internet/libcurl.c |  5 +++--
+ 4 files changed, 14 insertions(+), 14 deletions(-)
+
+diff --git a/configure b/configure
+index 75fbbe4a..a5a05baa 100755
+--- a/configure
++++ b/configure
+@@ -47603,8 +47603,8 @@ fi
+ done
+ 
+ if test "x${have_libcurl}" = "xyes"; then
+-{ printf "%s\n" "$as_me:${as_lineno-$LINENO}: checking if libcurl is version 7 and >= 7.28.0" >&5
+-printf %s "checking if libcurl is version 7 and >= 7.28.0... " >&6; }
++{ printf "%s\n" "$as_me:${as_lineno-$LINENO}: checking if libcurl is >= 7.28.0" >&5
++printf %s "checking if libcurl is >= 7.28.0... " >&6; }
+ if test ${r_cv_have_curl728+y}
+ then :
+   printf %s "(cached) " >&6
+@@ -47622,7 +47622,7 @@ int main(int argc, const char * argv[])
+ {
+ #ifdef LIBCURL_VERSION_MAJOR
+ #if LIBCURL_VERSION_MAJOR > 7
+-  exit(1);
++  exit(0);
+ #elif LIBCURL_VERSION_MAJOR == 7 && LIBCURL_VERSION_MINOR >= 28
+   exit(0);
+ #else
+diff --git a/doc/manual/R-admin.texi b/doc/manual/R-admin.texi
+index 5909b683..8400587e 100644
+--- a/doc/manual/R-admin.texi
++++ b/doc/manual/R-admin.texi
+@@ -3314,13 +3314,12 @@ by calling @code{pcre_config()}.
+ @c   end-of-life May 2018. 
+ @c libcurl 7.28.0 was released in Oct 2012
+ @c Ubuntu 16.04LTS has 7.47.0
+-Library @code{libcurl} (version 7.28.0 or later@footnote{but not a major
+-version greater than 7 should there ever be one: the major version has
+-been 7 since 2000.}) is required.  Information on @code{libcurl} is
+-found from the @command{curl-config} script: if that is missing or needs
+-to be overridden@footnote{for example to specify static linking with a
+-build which has both shared and static libraries.} there are macros to
+-do so described in file @file{config.site}.
++Library @code{libcurl} (version 7.28.0 or later) is required.
++Information on @code{libcurl} is found from the @command{curl-config}
++script: if that is missing or needs to be overridden@footnote{for
++example to specify static linking with a build which has both shared and
++static libraries.} there are macros to do so described in file
++@file{config.site}.
+ 
+ A @command{tar} program is needed to unpack the sources and packages
+ (including the recommended packages).  A version@footnote{Such as
+diff --git a/m4/R.m4 b/m4/R.m4
+index 3eda3f99..4c9f380b 100644
+--- a/m4/R.m4
++++ b/m4/R.m4
+@@ -4300,7 +4300,7 @@ LIBS="${CURL_LIBS} ${LIBS}"
+ AC_CHECK_HEADERS(curl/curl.h, [have_libcurl=yes], [have_libcurl=no])
+ 
+ if test "x${have_libcurl}" = "xyes"; then
+-AC_CACHE_CHECK([if libcurl is version 7 and >= 7.28.0], [r_cv_have_curl728],
++AC_CACHE_CHECK([if libcurl is >= 7.28.0], [r_cv_have_curl728],
+ [AC_RUN_IFELSE([AC_LANG_SOURCE([[
+ #include <stdlib.h>
+ #include <curl/curl.h>
+@@ -4308,7 +4308,7 @@ int main(int argc, const char * argv[])
+ {
+ #ifdef LIBCURL_VERSION_MAJOR
+ #if LIBCURL_VERSION_MAJOR > 7
+-  exit(1);
++  exit(0);
+ #elif LIBCURL_VERSION_MAJOR == 7 && LIBCURL_VERSION_MINOR >= 28
+   exit(0);
+ #else
+diff --git a/src/modules/internet/libcurl.c b/src/modules/internet/libcurl.c
+index 79e46ff2..66ebc745 100644
+--- a/src/modules/internet/libcurl.c
++++ b/src/modules/internet/libcurl.c
+@@ -584,7 +584,8 @@ in_do_curlDownload(SEXP call, SEXP op, SEXP args, SEXP rho)
+ 	/* Users will normally expect to follow redirections, although
+ 	   that is not the default in either curl or libcurl. */
+ 	curlCommon(hnd[i], 1, 1);
+-#if (LIBCURL_VERSION_MINOR >= 25)
++	// all but Unix-alikes with ancient libcurl (before 2012-03-22)
++#if (LIBCURL_VERSION_MAJOR > 7) || (LIBCURL_VERSION_MAJOR == 7 && LIBCURL_VERSION_MINOR >= 25)
+ 	curl_easy_setopt(hnd[i], CURLOPT_TCP_KEEPALIVE, 1L);
+ #endif
+ 	curl_easy_setopt(hnd[i], CURLOPT_HTTPHEADER, headers);
+@@ -894,7 +895,7 @@ static Rboolean Curl_open(Rconnection con)
+     curl_easy_setopt(ctxt->hnd, CURLOPT_FAILONERROR, 1L);
+     curlCommon(ctxt->hnd, 1, 1);
+     curl_easy_setopt(ctxt->hnd, CURLOPT_NOPROGRESS, 1L);
+-#if (LIBCURL_VERSION_MINOR >= 25)
++#if LIBCURL_VERSION_MAJOR > 7 || (LIBCURL_VERSION_MAJOR == 7 && LIBCURL_VERSION_MINOR >= 25)
+     curl_easy_setopt(ctxt->hnd, CURLOPT_TCP_KEEPALIVE, 1L);
+ #endif
+ 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -26,10 +26,11 @@ source:
     - 0014-link-Xt-to-uuid.patch
     - 0015-Check-for-changes-then-forcibly-mv-in-javareconf.in.patch
     - 0016-Use-LAPACK_LDFLAGS-in-Rlapack_la_LIBADD.patch
+    - 0017-allow-libcurl-8-as-its-API-ABI-is-said-to-be-unchang.patch
 
 build:
   skip: true  # [win]
-  number: 2
+  number: 3
 
 outputs:
   - name: r-base


### PR DESCRIPTION
<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [x] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
This sets up the (newly created) `4.2.x` branch to be included in `abi_migration_branches`.
For it to be effective, 9e7572040192e90d4663d47500f88f407a53ae74 needs to be cherry-picked on `main`, which we can do after merging this PR.
(It intentionally does not remove `4.1.x` yet; that one can be removed later when support for R 4.1 is removed from conda-forge; see https://github.com/conda-forge/conda-forge-pinning-feedstock/pull/4363 for progress on that discussion.)

This includes a patch added in gh-236 to the `4.1.x` branch to allow building with `libcurl=8` (the patch consists of squashed upstream patches already in R 4.3.0, i.e., the patch is not needed for `main` here).