### PR TITLE
Drop `--without-internal-tzcode` on OSX

### DIFF
--- a/.ci_support/migrations/pcre21042.yaml
+++ b/.ci_support/migrations/pcre21042.yaml
@@ -1,7 +1,0 @@
-__migrator:
-  build_number: 1
-  kind: version
-  migration_number: 1
-migrator_ts: 1698632312.9606004
-pcre2:
-- '10.42'

--- a/recipe/build-r-base.sh
+++ b/recipe/build-r-base.sh
@@ -485,11 +485,6 @@ Mingw_w64_makefiles() {
 Darwin() {
     unset JAVA_HOME
 
-    # --without-internal-tzcode to avoid warnings:
-    # unknown timezone 'Europe/London'
-    # unknown timezone 'GMT'
-    # https://stat.ethz.ch/pipermail/r-devel/2014-April/068745.html
-
     # May want to strip these from Makeconf at the end.
     CFLAGS="-isysroot ${CONDA_BUILD_SYSROOT} "${CFLAGS}
     LDFLAGS="-Wl,-dead_strip_dylibs -isysroot ${CONDA_BUILD_SYSROOT} "${LDFLAGS}
@@ -526,7 +521,6 @@ Darwin() {
                 --enable-R-shlib                    \
                 --enable-memory-profiling           \
                 --without-x                         \
-                --without-internal-tzcode           \
                 --enable-R-framework=no             \
                 --with-included-gettext=yes         \
                 --with-recommended-packages=no || (cat config.log; false)

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -27,7 +27,7 @@ source:
 
 build:
   skip: true  # [win]
-  number: 11
+  number: 12
 
 outputs:
   - name: r-base

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -197,9 +197,9 @@ outputs:
         - Rscript -e "stopifnot(capabilities('jpeg'), TRUE)"
         - Rscript -e "stopifnot(capabilities('png'), TRUE)"
         - if not exist %PREFIX%\\Lib\\R\\bin\\x64\\R.lib exit 1  # [win]
-        # Verify internal-tzcode works on macOS
+        # Verify internal-tzcode works without warnings
         # See https://stat.ethz.ch/pipermail/r-devel/2014-April/068745.html
-        - R -e "Sys.time()"  # [osx]
+        - R -e "options(warn=2);Sys.time()"
       files:
         - test-svg.R
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -197,6 +197,9 @@ outputs:
         - Rscript -e "stopifnot(capabilities('jpeg'), TRUE)"
         - Rscript -e "stopifnot(capabilities('png'), TRUE)"
         - if not exist %PREFIX%\\Lib\\R\\bin\\x64\\R.lib exit 1  # [win]
+        # Verify internal-tzcode works on macOS
+        # See https://stat.ethz.ch/pipermail/r-devel/2014-April/068745.html
+        - R -e "Sys.time()"  # [osx]
       files:
         - test-svg.R
 


### PR DESCRIPTION
A `--without-internal-tzcode` flag has been included in OSX builds since at least when [Conda Forge transferred R from `conda-recipes`](https://github.com/conda-forge/staged-recipes/pull/2047) (8 years ago). This appears to be a workaround for warnings thrown on `Sys.time()` calls and references back to [advice in this thread](https://stat.ethz.ch/pipermail/r-devel/2014-April/068745.html). As some downstream issues have raised some blame on this (see #290), we propose dropping this flag.

This PR drops the flag and adds a test of `Sys.time()` to check for any warning.

Resolves #290.

---

## Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.
