### PR TITLE
add 4.3.x to abi_migration_branches

### DIFF
--- a/conda-forge.yml
+++ b/conda-forge.yml
@@ -4,6 +4,7 @@ bot:
   abi_migration_branches:
   - 4.1.x
   - 4.2.x
+  - 4.3.x
 build_platform:
   osx_arm64: osx_64
 conda_build:


### PR DESCRIPTION
I added [a 4.3.x branch](https://github.com/conda-forge/r-base-feedstock/tree/4.3.x) to prep merging #297. This sets it for ABI migration support.

Should we also drop `4.1.x` here? Note that is our only Windows support - but maybe it's time to let that go.

We used to only sustain one lagging version. Should we drop `4.2.x` as well?

## Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [ ] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [ ] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [ ] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
