### PR TITLE
Fix libblas, liblapack symlinks on macOS

### DIFF
--- a/recipe/build-r-base.sh
+++ b/recipe/build-r-base.sh
@@ -455,15 +455,6 @@ Darwin() {
       exit 1
     fi
 
-    if [[ "$target_platform" == "osx-arm64" ]]; then
-      # For backwards compatibility
-      for lib in libblas.3 liblapack.3; do
-        # Use explicit relative path to prevent conda-build from using realpath
-        ln -sfn "../../${lib}.dylib" "${PREFIX}/lib/R/lib/${lib%.*}.dylib"
-        test -f "${PREFIX}/lib/R/lib/${lib}.dylib"
-      done
-    fi
-
     pushd ${PREFIX}/lib/R/etc
       sed -i'.bak' -r "s|-isysroot ${CONDA_BUILD_SYSROOT}||g" Makeconf
       sed -i'.bak' -r "s|$BUILD_PREFIX/lib/gcc|$PREFIX/lib/gcc|g" Makeconf

--- a/recipe/build-r-base.sh
+++ b/recipe/build-r-base.sh
@@ -457,8 +457,11 @@ Darwin() {
 
     if [[ "$target_platform" == "osx-arm64" ]]; then
       # For backwards compatibility
-      ln -sf ${PREFIX}/lib/libblas.dylib ${PREFIX}/lib/R/lib/libRblas.dylib
-      ln -sf ${PREFIX}/lib/liblapack.dylib ${PREFIX}/lib/R/lib/libRlapack.dylib
+      for lib in libblas.3 liblapack.3; do
+        # Use explicit relative path to prevent conda-build from using realpath
+        ln -sfn "../../${lib}.dylib" "${PREFIX}/lib/R/lib/${lib%.*}.dylib"
+        test -f "${PREFIX}/lib/R/lib/${lib}.dylib"
+      done
     fi
 
     pushd ${PREFIX}/lib/R/etc

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -26,7 +26,7 @@ source:
       - 0018-Fix-path-to-TCL-TK.patch
 
 build:
-  number: 6
+  number: 7
   no_link:
     - lib/R/doc/html/packages.html
 


### PR DESCRIPTION
Alternative implementation to
https://github.com/conda-forge/r-base-feedstock/pull/318 that avoids removing files from PREFIX.

<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [x] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [ ] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->
Alternative implementation to gh-318 that fixes gh-270 for `4.4`.

<!--
Please add any other relevant info below:
-->
