### PR TITLE
Fix COMPILED_BY entry on Windows

### DIFF
--- a/recipe/0015-Win32-Fix-COMPILED_BY-for-custom-GCC-pkgversion.patch
+++ b/recipe/0015-Win32-Fix-COMPILED_BY-for-custom-GCC-pkgversion.patch
@@ -1,0 +1,24 @@
+From 1bb4f73babfe04c01a811d8230e4733ba398da92 Mon Sep 17 00:00:00 2001
+From: Marcel Bargull <marcel.bargull@udo.edu>
+Date: Sun, 30 Jun 2024 22:57:23 +0200
+Subject: [PATCH] Win32: Fix COMPILED_BY for custom GCC pkgversion
+
+Signed-off-by: Marcel Bargull <marcel.bargull@udo.edu>
+---
+ src/gnuwin32/MkRules.rules | 3 ++-
+ 1 file changed, 2 insertions(+), 1 deletion(-)
+
+diff --git a/src/gnuwin32/MkRules.rules b/src/gnuwin32/MkRules.rules
+index 46bdb0b821..69b3318b50 100644
+--- a/src/gnuwin32/MkRules.rules
++++ b/src/gnuwin32/MkRules.rules
+@@ -11,7 +11,8 @@ ATLAS_PATH ?=
+ TOOL_PATH ?=
+ BINPREF64 ?= 
+ CCBASE = $(if $(USE_LLVM),clang,gcc)
+-COMPILED_BY ?= $(CCBASE)-$(shell $(CC) --version | grep -E -o "([0-9]{1,}\.){2,}[0-9]{1,}")
++# tail -n1 to skip matches in "gcc (CUSTOM) X.Y.Z" for GCC configured --with-pkgversion=CUSTOM
++COMPILED_BY ?= $(CCBASE)-$(shell $(CC) --version | head -n1 | grep -E -o "([0-9]{1,}\.){2,}[0-9]{1,}" | tail -n1)
+ M_ARCH ?=
+ AS_ARCH ?=
+ RC_ARCH ?=

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -23,10 +23,11 @@ source:
       - 0011-Check-for-changes-then-forcibly-mv-in-javareconf.in.patch
       - 0012-Use-LAPACK_LDFLAGS-in-Rlapack_la_LIBADD.patch
       - 0014-Use-conda-s-tzdata-package.patch
+      - 0015-Win32-Fix-COMPILED_BY-for-custom-GCC-pkgversion.patch
       - 0018-Fix-path-to-TCL-TK.patch
 
 build:
-  number: 7
+  number: 8
   no_link:
     - lib/R/doc/html/packages.html
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -182,6 +182,9 @@ outputs:
         - R -e "capabilities()"
         # Show third-party graphics software available
         - R -e "grSoftVersion()"
+        # Show environment variables set by R wrapper
+        - env | R -s -e "env <- Sys.getenv(names=TRUE); writeLines(setdiff(paste(names(env), env, sep='='), readLines(file('stdin'))))"  # [not win]
+        - set | R -s -e "env <- Sys.getenv(names=TRUE); writeLines(setdiff(paste(names(env), env, sep='='), readLines(file('stdin'))))"  # [win]
         # TODO does not work on windows, because winCairo.dll is missing
         - Rscript test-svg.R                 # [not win]
         - open                               # [win]

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -185,6 +185,8 @@ outputs:
         # Show environment variables set by R wrapper
         - env | R -s -e "env <- Sys.getenv(names=TRUE); writeLines(setdiff(paste(names(env), env, sep='='), readLines(file('stdin'))))"  # [not win]
         - set | R -s -e "env <- Sys.getenv(names=TRUE); writeLines(setdiff(paste(names(env), env, sep='='), readLines(file('stdin'))))"  # [win]
+        # Show configure variables
+        - R CMD config --all
         # TODO does not work on windows, because winCairo.dll is missing
         - Rscript test-svg.R                 # [not win]
         - open                               # [win]


### PR DESCRIPTION
<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [x] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [ ] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
In https://github.com/conda-forge/r-curl-feedstock/pull/32 we have a custom build script for Windows builds that parses `COMPILED_BY`.
In the current builds, we have
```
r-base-4.4.1-hc390f20_7/lib/R/etc/x64/Makeconf:27:COMPILED_BY = gcc-13.2.0 13.2.0
```
since we build our GCCs with a customized `pkgversion` that also includes the version number, e.g.,:
```sh
$CC --version | head -n1
x86_64-conda-linux-gnu-cc (conda-forge gcc 13.2.0-13) 13.2.0
```
. The added patch makes it choose the trailing plain version number.