### PR TITLE
Add OpenMP libs to host to get pinned versions

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -27,7 +27,7 @@ source:
       - 0018-Fix-path-to-TCL-TK.patch
 
 build:
-  number: 8
+  number: 9
   no_link:
     - lib/R/doc/html/packages.html
 
@@ -117,6 +117,8 @@ outputs:
         - llvm-openmp                         # [osx]
         - libgomp                             # [linux]
       host:
+        - llvm-openmp                         # [osx]
+        - libgomp                             # [linux]
         - readline                           # [not win]
         - libcurl
         - xz


### PR DESCRIPTION
<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [x] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [ ] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->
With `llvm-openmp` only in `build`, we get a `llvm-openmp>={{ llvm_openmp }}` dependency in `host` which will resolve to the highest possible version and in turn means we depend on the (usually) latest instead of the curated version from the pinning.
Adding `llvm-openmp` to `host` adds a `llvm-openmp={{ llvm_openmp }}.*` constraint via the pinning such that the lower bound-only `strong` `run_export` from the `build` requirements gets capped, as desired. 
<!--
Please add any other relevant info below:
-->
See discussion in https://github.com/conda-forge/openmp-feedstock/issues/126 .