### PR TITLE
4.3.x: Add OpenMP libs to host to get pinned versions (backport of #323)

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -29,7 +29,7 @@ source:
       - 0018-Fix-path-to-TCL-TK.patch
 
 build:
-  number: 7
+  number: 8
   no_link:
     - lib/R/doc/html/packages.html
 
@@ -117,6 +117,8 @@ outputs:
         - llvm-openmp                         # [osx]
         - libgomp                             # [linux]
       host:
+        - llvm-openmp                         # [osx]
+        - libgomp                             # [linux]
         - readline                           # [not win]
         - libcurl
         - xz


### PR DESCRIPTION
Add OpenMP libs to host to get pinned versions

<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [x] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [ ] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->
Backport of gh-323
<!--
Please add any other relevant info below:
-->
