### PR TITLE
4.3.x: Fix build to remove rtools parts (backport of #326) 

### DIFF
--- a/recipe/build-r-base.sh
+++ b/recipe/build-r-base.sh
@@ -337,6 +337,9 @@ Mingw_w64_makefiles() {
     # Allow overriding TCL_VERSION
     sed -i 's|TCL_VERSION = 86|TCL_VERSION = 86t|g' "${SRC_DIR}/src/gnuwin32/fixed/etc/Makeconf"
 
+    # We are not using rtools
+    sed -i 's|# INSTALLER-BUILD|# INSTALLER-BUILD2|g' "${SRC_DIR}/src/gnuwin32/installer/Makefile"
+
     # R_ARCH looks like an absolute path (e.g. "/x64"), so MSYS2 will convert it.
     # We need to prevent that from happening.
     export MSYS2_ARG_CONV_EXCL="R_ARCH"
@@ -372,11 +375,6 @@ Mingw_w64_makefiles() {
     # Copied to ${PREFIX}/lib to mirror the unix layout so we can use "noarch: generic" packages for any that do not require compilation.
     mkdir -p "${PREFIX}"/lib
     cp -Rf R-${PKG_VERSION}/. "${PREFIX}"/lib/R
-
-    # We are not using rtools
-    for _makeconf in $(find "${PREFIX}"/lib/R -name Makeconf); do
-        sed -i 's|R_INSTALLER_BUILD = yes|R_INSTALLER_BUILD = no|g' ${_makeconf}
-    done
 
     rm -rf ${PREFIX}/lib/R/share/zoneinfo
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -29,7 +29,7 @@ source:
       - 0018-Fix-path-to-TCL-TK.patch
 
 build:
-  number: 8
+  number: 9
   no_link:
     - lib/R/doc/html/packages.html
 


### PR DESCRIPTION
<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [x] Reset the build number to `0` (if the version changed)
* [ ] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [ ] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->
Backport of gh-326.
<!--
Please add any other relevant info below:
-->
