### PR TITLE
Backport patch for CVE-2024-27322 to 4.2

### DIFF
--- a/recipe/0018-CVE-2024-27322.patch
+++ b/recipe/0018-CVE-2024-27322.patch
@@ -1,0 +1,49 @@
+From f7c46500f455eb4edfc3656c3fa20af61b16abb7 Mon Sep 17 00:00:00 2001
+From: luke <luke@00db46b3-68df-0310-9c12-caf00c1e9a41>
+Date: Sun, 31 Mar 2024 19:35:58 +0000
+Subject: [PATCH] readRDS() and unserialize() now signal an errorr instead of
+ returning a PROMSXP.
+
+git-svn-id: https://svn.r-project.org/R/trunk@86235 00db46b3-68df-0310-9c12-caf00c1e9a41
+---
+ src/main/serialize.c | 13 ++++++++++---
+ 1 file changed, 10 insertions(+), 3 deletions(-)
+
+diff --git a/src/main/serialize.c b/src/main/serialize.c
+index a389f713116..a190fbf8f3c 100644
+--- a/src/main/serialize.c
++++ b/src/main/serialize.c
+@@ -2650,6 +2650,13 @@ do_serializeToConn(SEXP call, SEXP op, SEXP args, SEXP env)
+     return R_NilValue;
+ }
+ 
++static SEXP checkNotPromise(SEXP val)
++{
++    if (TYPEOF(val) == PROMSXP)
++	error(_("cannot return a promise (PROMSXP) object"));
++    return val;
++}
++
+ /* unserializeFromConn(conn, hook) used from readRDS().
+    It became public in R 2.13.0, and that version added support for
+    connections internally */
+@@ -2699,7 +2706,7 @@ do_unserializeFromConn(SEXP call, SEXP op, SEXP args, SEXP env)
+ 	con->close(con);
+ 	UNPROTECT(1);
+     }
+-    return ans;
++    return checkNotPromise(ans);
+ }
+ 
+ /*
+@@ -3330,8 +3337,8 @@ attribute_hidden SEXP
+ do_serialize(SEXP call, SEXP op, SEXP args, SEXP env)
+ {
+     checkArity(op, args);
+-    if (PRIMVAL(op) == 2) return R_unserialize(CAR(args), CADR(args));
+-
++    if (PRIMVAL(op) == 2) //return R_unserialize(CAR(args), CADR(args));
++	return checkNotPromise(R_unserialize(CAR(args), CADR(args)));
+     SEXP object, icon, type, ver, fun;
+     object = CAR(args); args = CDR(args);
+     icon = CAR(args); args = CDR(args);

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -24,10 +24,11 @@ source:
     - 0015-Check-for-changes-then-forcibly-mv-in-javareconf.in.patch
     - 0016-Use-LAPACK_LDFLAGS-in-Rlapack_la_LIBADD.patch
     - 0017-allow-libcurl-8-as-its-API-ABI-is-said-to-be-unchang.patch
+    - 0018-CVE-2024-27322.patch
 
 build:
   skip: true  # [win]
-  number: 15
+  number: 16
 
 outputs:
   - name: r-base


### PR DESCRIPTION
<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [ ] Ensured the license file is being packaged.

---

Downloaded the patch from https://github.com/r-devel/r-svn/commit/f7c46500f455eb4edfc3656c3fa20af61b16abb7.patch

Rerendering resulted in no changes

xref: #338, #297, #340

**Warning to end users:** This patch only prevents an obscure (though admittedly now well publicized) vulnerability. Unserializing R data objects (RDS, RDATA) is still inherently insecure, and you should continue to only load such objects from trusted sources.
