### PR TITLE
ABI migrations add 4.5, drop 4.3

### DIFF
--- a/conda-forge.yml
+++ b/conda-forge.yml
@@ -2,8 +2,8 @@ azure:
   store_build_artifacts: true
 bot:
   abi_migration_branches:
-  - 4.3.x
   - 4.4.x
+  - 4.5.x
 build_platform:
   linux_aarch64: linux_64
   linux_ppc64le: linux_64


### PR DESCRIPTION
Updating ABI migrations to add `4.5.x` and drop `4.3.x` branches.

## Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
