### PR TITLE
[4.4.x] Drop `-lheapt_w` in Makeconf

### DIFF
--- a/recipe/build-r-base.sh
+++ b/recipe/build-r-base.sh
@@ -462,6 +462,7 @@ Darwin() {
       sed -i'.bak' -r "s|-isysroot ${CONDA_BUILD_SYSROOT}||g" Makeconf
       sed -i'.bak' -r "s|$BUILD_PREFIX/lib/gcc|$PREFIX/lib/gcc|g" Makeconf
       sed -i'.bak' -r "s|-lemutls_w||g" Makeconf
+      sed -i'.bak' -r "s|-lheapt_w||g" Makeconf
       sed -i'.bak' -r "s/-mmacosx-version-min=${MACOSX_DEPLOYMENT_TARGET}//g" Makeconf
       rm Makeconf.bak
       # See: https://github.com/conda/conda/issues/6701

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -27,7 +27,7 @@ source:
       - 0018-Fix-path-to-TCL-TK.patch
 
 build:
-  number: 10
+  number: 11
   no_link:
     - lib/R/doc/html/packages.html
 


### PR DESCRIPTION
Avoid unnecessary library searching on macOS. See #413 

<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
