### PR TITLE
add a dsolist to r-base

### DIFF
--- a/recipe/build-r-base.sh
+++ b/recipe/build-r-base.sh
@@ -503,6 +503,11 @@ case "${target_platform}" in
       cp "${RECIPE_DIR}/${action}-${PKG_NAME}.sh" "${PREFIX}/etc/conda/${action}.d/"
     done
     ;;
+  win-* )
+    mkdir -p "${PREFIX}/etc/conda-build/dsolists.d"
+    sed "s/<SUBDIR>/${target_platform}/g" ${RECIPE_DIR}/dsolists.json > "${PREFIX}/etc/conda-build/dsolists.d/r-base.json"
+    cat "${PREFIX}/etc/conda-build/dsolists.d/r-base.json"
+    ;;
 esac
 
 if [[ "$CONDA_BUILD_CROSS_COMPILATION" == "1" ]]; then

--- a/recipe/dsolist.json
+++ b/recipe/dsolist.json
@@ -1,0 +1,9 @@
+{
+  "version": 1,
+  "deny": [
+    "**/R.dll",
+    "**/Rblas.dll",
+    "**/Rlapack.dll",
+  ],    
+  "subdir": "dummy",
+} 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -27,7 +27,7 @@ source:
       - 0018-Fix-path-to-TCL-TK.patch
 
 build:
-  number: 1
+  number: 2
   no_link:
     - lib/R/doc/html/packages.html
 


### PR DESCRIPTION
This makes the warnings from conda-build about R.dll, Rblas.dll and Rlapack.dll missing, go away.

<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [ ] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [ ] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [ ] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [ ] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
